### PR TITLE
Point PWA icons to provided hosted assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,9 +15,9 @@
   <link rel="manifest" href="manifest.json">
   
   <!-- Icons -->
-  <link rel="apple-touch-icon" href="icon-192.png">
-  <link rel="icon" type="image/png" sizes="192x192" href="icon-192.png">
-  <link rel="icon" type="image/png" sizes="512x512" href="icon-512.png">
+  <link rel="apple-touch-icon" href="https://storage.googleapis.com/intelechia-content/download%20small.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="https://storage.googleapis.com/intelechia-content/download%20small.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="https://storage.googleapis.com/intelechia-content/download%20large.png">
   
   <title>Secure P2P Chat</title>
   

--- a/manifest.json
+++ b/manifest.json
@@ -10,13 +10,13 @@
   "theme_color": "#000000",
   "icons": [
     {
-      "src": "icon-192.png",
+      "src": "https://storage.googleapis.com/intelechia-content/download%20small.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "icon-512.png",
+      "src": "https://storage.googleapis.com/intelechia-content/download%20large.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/sw.js
+++ b/sw.js
@@ -1,10 +1,8 @@
-const CACHE_NAME = 'secure-chat-v1';
+const CACHE_NAME = 'secure-chat-v2';
 const urlsToCache = [
   './',
   './index.html',
   './manifest.json',
-  './icon-192.png',
-  './icon-512.png',
   'https://unpkg.com/peerjs@1.5.1/dist/peerjs.min.js'
 ];
 


### PR DESCRIPTION
## Summary
- reference the provided hosted icon assets in the PWA manifest and head metadata
- remove the generated placeholder icons and bump the service worker cache to avoid stale entries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d1e880afd88332a008e1c8aa0f02e9