### PR TITLE
Ensure host chat view opens immediately after room creation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1023,6 +1023,18 @@
         }
       }
 
+      async persistRoom() {
+        if (!this.roomId || typeof this.storage?.saveRoom !== 'function') {
+          return;
+        }
+
+        try {
+          await this.storage.saveRoom(this.roomId);
+        } catch (error) {
+          console.warn('Failed to save room history.', error);
+        }
+      }
+
       quickJoin(roomId) {
         document.getElementById('joinCode').value = roomId;
         this.showJoin();
@@ -1182,11 +1194,7 @@
             this.addSystemMessage(`Room created: ${this.roomId}`);
             this.addSystemMessage('Waiting for someone to join...');
 
-            try {
-              this.storage?.saveRoom?.(this.roomId);
-            } catch (error) {
-              console.warn('Failed to save room history.', error);
-            }
+            await this.persistRoom();
           } else {
             const conn = this.peer.connect(this.roomId);
             this.setupConnection(conn);
@@ -1197,13 +1205,14 @@
           this.peer.on('connection', (conn) => {
             console.log('Peer connecting');
             this.addSystemMessage('Peer is connecting...');
+            this.updateStatus('Peer connecting...', 'connecting');
             this.setupConnection(conn);
           });
         }
 
         this.peer.on('error', (err) => {
           console.error('Peer error:', err);
-          
+
           if (err.type === 'peer-unavailable') {
             this.addSystemMessage('❌ Room not found. Make sure the room code is correct.');
             this.updateStatus('Error', '');
@@ -1239,11 +1248,7 @@
             this.showChat();
           }
 
-          try {
-            this.storage?.saveRoom?.(this.roomId);
-          } catch (error) {
-            console.warn('Failed to save room history.', error);
-          }
+          await this.persistRoom();
 
           if (typeof this.storage?.getMessages === 'function') {
             try {


### PR DESCRIPTION
## Summary
- ensure the host immediately sees the chat UI when the peer connection opens
- centralize room persistence logic in a helper and reuse it for host/guest flows
- improve connection status updates when a guest connects to the host

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d21a5ddf388332975032c255276ab8