### PR TITLE
Add encrypted view toggle and data schema modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,6 +395,37 @@
       align-items: center;
     }
 
+    .view-toggles {
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+      margin-right: auto;
+      margin-left: 1.5rem;
+    }
+
+    .toggle-btn {
+      padding: 0.5rem 1rem;
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      color: var(--text-primary);
+      cursor: pointer;
+      transition: all 0.3s ease;
+      font-size: 0.85rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+
+    .toggle-btn:hover {
+      background: #333;
+    }
+
+    .toggle-btn.active {
+      background: var(--accent);
+      border-color: var(--accent);
+    }
+
     .waiting-banner {
       display: none;
       margin: 1.5rem;
@@ -562,6 +593,41 @@
       animation: messageIn 0.3s ease;
     }
 
+    .message.encrypted-view .message-content {
+      font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+      background: rgba(0, 102, 255, 0.12);
+      border: 1px solid rgba(0, 102, 255, 0.3);
+      color: var(--text-primary);
+    }
+
+    .encrypted-data {
+      font-size: 0.75rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+
+    .data-label {
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .data-hex {
+      word-break: break-all;
+      color: var(--text-secondary);
+      line-height: 1.4;
+    }
+
+    .data-info {
+      color: var(--text-secondary);
+      opacity: 0.7;
+      margin-top: 0.25rem;
+      font-size: 0.7rem;
+    }
+
     .chat-input-container {
       padding: 1.5rem;
       background: rgba(0, 0, 0, 0.8);
@@ -622,6 +688,166 @@
     .send-btn:disabled {
       opacity: 0.5;
       cursor: not-allowed;
+    }
+
+    .schema-modal {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0, 0, 0, 0.9);
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      z-index: 1000;
+      overflow-y: auto;
+      padding: 2rem;
+    }
+
+    .schema-content {
+      max-width: 960px;
+      margin: 0 auto;
+      background: var(--bg-secondary);
+      border-radius: 16px;
+      padding: 2rem;
+      box-shadow: 0 25px 60px rgba(0, 0, 0, 0.6);
+    }
+
+    .schema-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 2rem;
+      padding-bottom: 1rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .schema-header button {
+      border: none;
+      background: var(--bg-tertiary);
+      color: var(--text-secondary);
+      border-radius: 8px;
+      padding: 0.4rem 0.75rem;
+      cursor: pointer;
+      transition: background 0.3s ease;
+    }
+
+    .schema-header button:hover {
+      background: #333;
+    }
+
+    .schema-section {
+      margin: 2rem 0;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .schema-section h3 {
+      color: var(--accent);
+      font-size: 1.1rem;
+    }
+
+    .schema-code {
+      background: var(--bg-primary);
+      padding: 1rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      border: 1px solid var(--border);
+    }
+
+    .schema-code pre {
+      margin: 0;
+      color: var(--text-secondary);
+      font-size: 0.85rem;
+      line-height: 1.6;
+    }
+
+    .schema-tabs {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .tab-btn {
+      padding: 0.5rem 0.85rem;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      background: var(--bg-tertiary);
+      color: var(--text-primary);
+      cursor: pointer;
+      font-size: 0.8rem;
+      transition: all 0.3s ease;
+    }
+
+    .tab-btn.active {
+      background: var(--accent);
+      border-color: var(--accent);
+    }
+
+    .tab-content {
+      display: none;
+      background: var(--bg-primary);
+      padding: 1rem;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      max-height: 360px;
+      overflow-y: auto;
+      font-size: 0.8rem;
+    }
+
+    .tab-content.active {
+      display: block;
+    }
+
+    .events-timeline {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .event-item {
+      padding: 0.75rem;
+      background: var(--bg-tertiary);
+      border-radius: 10px;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
+    .event-op {
+      font-weight: 600;
+      color: var(--accent);
+      margin-bottom: 0.25rem;
+      font-size: 0.85rem;
+    }
+
+    .event-details {
+      color: var(--text-secondary);
+      font-size: 0.75rem;
+      display: flex;
+      justify-content: space-between;
+      gap: 0.5rem;
+      margin-bottom: 0.35rem;
+    }
+
+    .event-payload {
+      font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+      word-break: break-all;
+      white-space: pre-wrap;
+    }
+
+    .storage-diagram {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .storage-layer {
+      background: var(--bg-primary);
+      border-radius: 12px;
+      border-left: 3px solid var(--accent);
+      padding: 1rem 1.25rem;
+      line-height: 1.5;
     }
 
     /* Room History */
@@ -697,6 +923,19 @@
         font-size: 1.2rem;
         letter-spacing: 0.2rem;
       }
+
+      .chat-header {
+        flex-wrap: wrap;
+        gap: 0.75rem;
+      }
+
+      .view-toggles {
+        order: 3;
+        width: 100%;
+        margin: 0;
+        justify-content: flex-start;
+        gap: 0.5rem;
+      }
     }
 
     @media (max-width: 480px) {
@@ -727,6 +966,16 @@
 
       #chatCopyLink {
         width: 100%;
+      }
+
+      .view-toggles {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .toggle-btn {
+        width: 100%;
+        justify-content: center;
       }
     }
 
@@ -869,6 +1118,16 @@
           <div class="chat-room-info">
             <span>🔐</span>
             <div class="room-badge" id="currentRoom">xxx-xxx-xxx</div>
+          </div>
+          <div class="view-toggles">
+            <button id="encryptedToggle" class="toggle-btn" onclick="app.toggleEncryptedView()">
+              <span>🔍</span>
+              Encrypted View
+            </button>
+            <button id="schemaToggle" class="toggle-btn" onclick="app.showSchemaView()">
+              <span>📊</span>
+              Data Schema
+            </button>
           </div>
           <button class="btn btn-secondary" style="padding: 0.5rem 1rem;" onclick="app.disconnect()">
             Leave
@@ -1405,6 +1664,9 @@
         this.currentShareLink = '';
         this.localUserId = generateId('user-');
         this.remoteUserId = null;
+        this.showEncrypted = false;
+        this.messageLog = [];
+        this.lastEncryptedHex = '';
 
         this.initStorage();
         this.loadRoomHistory();
@@ -1877,7 +2139,7 @@
             try {
               const messages = await this.storage.getMessages(this.roomId);
               messages.forEach((msg) => {
-                this.displayMessage(msg.content, msg.type || 'them');
+                this.displayMessage(msg.content, msg.type || 'them', msg.at);
               });
             } catch (error) {
               console.error('Failed to load stored messages:', error);
@@ -1886,9 +2148,13 @@
         });
 
         activeConn.on('data', async (data) => {
-          const decrypted = await this.decrypt(new Uint8Array(data));
+          const payload = data instanceof Uint8Array ? data : new Uint8Array(data);
+          this.lastEncryptedHex = Array.from(payload)
+            .map(b => b.toString(16).padStart(2, '0'))
+            .join('');
+          const decrypted = await this.decrypt(payload);
           if (decrypted) {
-            this.displayMessage(decrypted, 'them');
+            this.displayMessage(decrypted, 'them', Date.now(), payload);
             if (typeof this.storage?.recordMessage === 'function' && this.roomId) {
               this.storage.recordMessage({
                 roomId: this.roomId,
@@ -1925,11 +2191,28 @@
       async sendMessage() {
         const input = document.getElementById('messageInput');
         const text = input.value.trim();
-        
-        if (!text || !this.conn) return;
+
+        if (!text || !this.conn) {
+          return;
+        }
 
         input.value = '';
-        this.displayMessage(text, 'me');
+        const timestamp = Date.now();
+
+        let encrypted;
+        try {
+          encrypted = await this.encrypt(text);
+        } catch (error) {
+          console.error('Failed to encrypt message.', error);
+          this.addSystemMessage('⚠️ Unable to encrypt message');
+          return;
+        }
+
+        this.lastEncryptedHex = Array.from(encrypted)
+          .map(b => b.toString(16).padStart(2, '0'))
+          .join('');
+
+        this.displayMessage(text, 'me', timestamp, encrypted);
 
         if (typeof this.storage?.recordMessage === 'function' && this.roomId) {
           this.storage.recordMessage({
@@ -1941,45 +2224,430 @@
           }).catch(error => console.warn('Failed to record outgoing message.', error));
         }
 
-        const encrypted = await this.encrypt(text);
-        this.conn.send(encrypted);
+        if (this.conn) {
+          this.conn.send(encrypted);
+        }
       }
 
-      displayMessage(text, type) {
+      toggleEncryptedView() {
+        this.showEncrypted = !this.showEncrypted;
+        const toggle = document.getElementById('encryptedToggle');
+        if (toggle) {
+          toggle.classList.toggle('active', this.showEncrypted);
+        }
+        this.renderChatMessages();
+      }
+
+      renderChatMessages() {
         const container = document.getElementById('chatMessages');
-        
+        if (!container) {
+          return;
+        }
+
+        container.innerHTML = '';
+
+        this.messageLog.forEach((entry) => {
+          let element = null;
+
+          if (entry.kind === 'system') {
+            element = this.createSystemMessageElement(entry);
+          } else if (entry.kind === 'message') {
+            if (this.showEncrypted) {
+              element = entry.encrypted
+                ? this.createEncryptedMessageElement(entry)
+                : this.createEncryptedPlaceholderElement(entry);
+            } else {
+              element = this.createPlainMessageElement(entry);
+            }
+          }
+
+          if (element) {
+            container.appendChild(element);
+          }
+        });
+
+        container.scrollTop = container.scrollHeight;
+      }
+
+      createPlainMessageElement(entry) {
+        const { text, type, at } = entry;
         const message = document.createElement('div');
         message.className = `message ${type}`;
-        
+
         const content = document.createElement('div');
         content.className = 'message-content';
-        
+
         const textEl = document.createElement('div');
         textEl.className = 'message-text';
         textEl.textContent = text;
-        
+
         const timeEl = document.createElement('div');
         timeEl.className = 'message-time';
-        timeEl.textContent = new Date().toLocaleTimeString([], { 
-          hour: '2-digit', 
-          minute: '2-digit' 
-        });
-        
+        timeEl.textContent = this.formatTimestamp(at);
+
         content.appendChild(textEl);
         content.appendChild(timeEl);
         message.appendChild(content);
-        
-        container.appendChild(message);
-        container.scrollTop = container.scrollHeight;
+
+        return message;
+      }
+
+      createEncryptedMessageElement(entry) {
+        const { encrypted, type, at } = entry;
+        const payload = encrypted instanceof Uint8Array ? encrypted : this.toUint8Array(encrypted);
+
+        if (!(payload instanceof Uint8Array) || payload.length === 0) {
+          return this.createEncryptedPlaceholderElement(entry);
+        }
+
+        const message = document.createElement('div');
+        message.className = `message ${type} encrypted-view`;
+
+        const content = document.createElement('div');
+        content.className = 'message-content';
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'encrypted-data';
+
+        const iv = payload.slice(0, 12);
+        const ciphertext = payload.slice(12);
+
+        const ivLabel = document.createElement('div');
+        ivLabel.className = 'data-label';
+        ivLabel.textContent = `IV (${iv.length} bytes):`;
+
+        const ivHex = document.createElement('div');
+        ivHex.className = 'data-hex';
+        const ivHexInfo = this.hexFromBytes(iv);
+        ivHex.textContent = ivHexInfo.text || '—';
+
+        const cipherLabel = document.createElement('div');
+        cipherLabel.className = 'data-label';
+        cipherLabel.textContent = 'Ciphertext:';
+
+        const cipherHex = document.createElement('div');
+        cipherHex.className = 'data-hex';
+        const cipherHexInfo = this.hexFromBytes(ciphertext, 60);
+        cipherHex.textContent = cipherHexInfo.text || '—';
+
+        const info = document.createElement('div');
+        info.className = 'data-info';
+        const segments = [`Total: ${payload.length} bytes`];
+        if (cipherHexInfo.truncated) {
+          segments.push('Preview limited to first 60 bytes');
+        }
+        segments.push(this.formatTimestamp(at));
+        info.textContent = segments.join(' • ');
+
+        wrapper.appendChild(ivLabel);
+        wrapper.appendChild(ivHex);
+        wrapper.appendChild(cipherLabel);
+        wrapper.appendChild(cipherHex);
+        wrapper.appendChild(info);
+
+        content.appendChild(wrapper);
+        message.appendChild(content);
+
+        return message;
+      }
+
+      createEncryptedPlaceholderElement(entry) {
+        const { type, at } = entry;
+        const message = document.createElement('div');
+        message.className = `message ${type} encrypted-view`;
+
+        const content = document.createElement('div');
+        content.className = 'message-content';
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'encrypted-data';
+
+        const label = document.createElement('div');
+        label.className = 'data-label';
+        label.textContent = 'Encrypted Payload';
+
+        const details = document.createElement('div');
+        details.className = 'data-hex';
+        details.textContent = 'Unavailable (loaded from history)';
+
+        const info = document.createElement('div');
+        info.className = 'data-info';
+        info.textContent = this.formatTimestamp(at);
+
+        wrapper.appendChild(label);
+        wrapper.appendChild(details);
+        wrapper.appendChild(info);
+
+        content.appendChild(wrapper);
+        message.appendChild(content);
+
+        return message;
+      }
+
+      createSystemMessageElement(entry) {
+        const message = document.createElement('div');
+        message.className = 'system-message';
+        message.textContent = entry.text;
+        return message;
+      }
+
+      formatTimestamp(at) {
+        const value = typeof at === 'number' ? at : Date.now();
+        return new Date(value).toLocaleTimeString([], {
+          hour: '2-digit',
+          minute: '2-digit'
+        });
+      }
+
+      hexFromBytes(data, limit) {
+        if (!(data instanceof Uint8Array)) {
+          return { text: '', truncated: false };
+        }
+
+        const bytes = Array.from(data);
+        const shouldLimit = typeof limit === 'number' && limit > 0;
+        const truncated = shouldLimit && bytes.length > limit;
+        const slice = shouldLimit ? bytes.slice(0, limit) : bytes;
+        const text = slice.map(b => b.toString(16).padStart(2, '0')).join(' ');
+        return {
+          text: truncated ? `${text} ...` : text,
+          truncated
+        };
+      }
+
+      toUint8Array(data) {
+        if (!data) {
+          return null;
+        }
+        if (data instanceof Uint8Array) {
+          return data.slice();
+        }
+        if (ArrayBuffer.isView(data) && data.buffer) {
+          return new Uint8Array(data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength));
+        }
+        if (data instanceof ArrayBuffer) {
+          return new Uint8Array(data);
+        }
+        return null;
+      }
+
+      displayMessage(text, type, at = Date.now(), encryptedData = null) {
+        const entry = {
+          kind: 'message',
+          text: typeof text === 'string' ? text : '',
+          type: type === 'me' ? 'me' : 'them',
+          at: typeof at === 'number' ? at : Date.now(),
+          encrypted: this.toUint8Array(encryptedData)
+        };
+
+        this.messageLog.push(entry);
+        this.renderChatMessages();
       }
 
       addSystemMessage(text) {
-        const container = document.getElementById('chatMessages');
-        const message = document.createElement('div');
-        message.className = 'system-message';
-        message.textContent = text;
-        container.appendChild(message);
-        container.scrollTop = container.scrollHeight;
+        this.messageLog.push({
+          kind: 'system',
+          text,
+          at: Date.now()
+        });
+        this.renderChatMessages();
+      }
+
+      async showSchemaView() {
+        if (this.storage?.ready) {
+          try {
+            await this.storage.ready;
+          } catch (error) {
+            console.warn('Storage not ready for schema view.', error);
+          }
+        }
+
+        let state = this.storage?.state;
+        if (!(state instanceof ChatState)) {
+          state = new ChatState();
+        }
+
+        let snapshot;
+        try {
+          snapshot = serializeState(state);
+        } catch (error) {
+          console.warn('Unable to serialize state snapshot.', error);
+          snapshot = serializeState(new ChatState());
+        }
+
+        let recentEvents = [];
+        if (typeof this.storage?.loadEventsAfter === 'function') {
+          try {
+            recentEvents = await this.storage.loadEventsAfter(Date.now() - 86400000);
+          } catch (error) {
+            console.warn('Unable to load recent events.', error);
+            recentEvents = [];
+          }
+        }
+
+        if (!Array.isArray(recentEvents)) {
+          recentEvents = [];
+        }
+
+        recentEvents.sort((a, b) => (a.at || 0) - (b.at || 0));
+        const timelineEvents = recentEvents.slice(-20);
+
+        const existingModal = document.querySelector('.schema-modal');
+        if (existingModal) {
+          existingModal.remove();
+        }
+
+        const roomsCount = snapshot.rooms?.length || 0;
+        const messagesCount = snapshot.messages?.length || 0;
+        const eventsCount = recentEvents.length;
+
+        const modal = document.createElement('div');
+        modal.className = 'schema-modal';
+        modal.innerHTML = `
+          <div class="schema-content">
+            <div class="schema-header">
+              <h2>Data Architecture</h2>
+              <button type="button" aria-label="Close schema view">✕</button>
+            </div>
+            <div class="schema-section">
+              <h3>Event Log Structure</h3>
+              <div class="schema-code">
+                <pre>{
+  id: "evt-xxxx",
+  op: "MessagePosted" | "RoomCreated" | "UserJoined" | ...,
+  payload: { /* operation-specific data */ },
+  actor: "user-id",
+  refs: ["room:xxx", "msg:xxx"],
+  at: timestamp,
+  semver: "1.0.0"
+}</pre>
+              </div>
+            </div>
+            <div class="schema-section">
+              <h3>Current State Snapshot</h3>
+              <div class="schema-tabs">
+                <button class="tab-btn active" data-tab="schema-rooms">Rooms (${roomsCount})</button>
+                <button class="tab-btn" data-tab="schema-messages">Messages (${messagesCount})</button>
+                <button class="tab-btn" data-tab="schema-events">Events (${eventsCount})</button>
+              </div>
+              <div id="schema-rooms" class="tab-content active"><pre></pre></div>
+              <div id="schema-messages" class="tab-content"><pre></pre></div>
+              <div id="schema-events" class="tab-content"><div class="events-timeline"></div></div>
+            </div>
+            <div class="schema-section">
+              <h3>Storage Layers</h3>
+              <div class="storage-diagram">
+                <div class="storage-layer">
+                  <strong>IndexedDB Stores:</strong>
+                  <ul>
+                    <li>events: All domain events (append-only log)</li>
+                    <li>snapshots: Periodic state snapshots</li>
+                    <li>blobs: Binary attachments (future)</li>
+                  </ul>
+                </div>
+                <div class="storage-layer">
+                  <strong>In-Memory State (ChatState):</strong>
+                  <ul>
+                    <li>rooms: Map&lt;roomId, RoomData&gt;</li>
+                    <li>messages: Map&lt;messageId, Message&gt;</li>
+                    <li>byRoom: Map&lt;roomId, messageId[]&gt;</li>
+                    <li>reactions: Map&lt;messageId, Map&lt;emoji, Set&lt;userId&gt;&gt;&gt;</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+            <div class="schema-section">
+              <h3>Encryption Details</h3>
+              <div class="schema-code">
+                <pre>Key Derivation: PBKDF2 (100,000 iterations, SHA-256)
+Encryption: AES-GCM (256-bit key)
+Message Format: [IV (12 bytes)][Ciphertext (variable)]
+Current Key: ${this.cryptoKey ? 'Loaded ✓' : 'Not set ✗'}</pre>
+              </div>
+            </div>
+          </div>
+        `;
+
+        const roomsPre = modal.querySelector('#schema-rooms pre');
+        if (roomsPre) {
+          roomsPre.textContent = JSON.stringify(snapshot.rooms || [], null, 2);
+        }
+
+        const messagesPre = modal.querySelector('#schema-messages pre');
+        if (messagesPre) {
+          const recentMessages = Array.isArray(snapshot.messages)
+            ? snapshot.messages.slice(-10)
+            : [];
+          messagesPre.textContent = JSON.stringify(recentMessages, null, 2);
+        }
+
+        const eventsTimeline = modal.querySelector('#schema-events .events-timeline');
+        if (eventsTimeline) {
+          if (timelineEvents.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'event-item';
+            empty.textContent = 'No events captured in the last 24 hours.';
+            eventsTimeline.appendChild(empty);
+          } else {
+            timelineEvents.forEach((event) => {
+              const item = document.createElement('div');
+              item.className = 'event-item';
+
+              const op = document.createElement('div');
+              op.className = 'event-op';
+              op.textContent = event.op || 'Unknown Event';
+
+              const details = document.createElement('div');
+              details.className = 'event-details';
+
+              const idSpan = document.createElement('span');
+              idSpan.className = 'event-id';
+              idSpan.textContent = event.id || '—';
+
+              const timeSpan = document.createElement('span');
+              timeSpan.className = 'event-time';
+              timeSpan.textContent = new Date(event.at || Date.now()).toLocaleString();
+
+              details.appendChild(idSpan);
+              details.appendChild(timeSpan);
+
+              const payload = document.createElement('div');
+              payload.className = 'event-payload';
+              payload.textContent = JSON.stringify(event.payload ?? {}, null, 2);
+
+              item.appendChild(op);
+              item.appendChild(details);
+              item.appendChild(payload);
+
+              eventsTimeline.appendChild(item);
+            });
+          }
+        }
+
+        const closeBtn = modal.querySelector('.schema-header button');
+        if (closeBtn) {
+          closeBtn.addEventListener('click', () => modal.remove());
+        }
+
+        modal.addEventListener('click', (event) => {
+          if (event.target === modal) {
+            modal.remove();
+          }
+        });
+
+        modal.querySelectorAll('.tab-btn').forEach((btn) => {
+          btn.addEventListener('click', () => {
+            modal.querySelectorAll('.tab-btn').forEach((b) => b.classList.remove('active'));
+            modal.querySelectorAll('.tab-content').forEach((content) => content.classList.remove('active'));
+            btn.classList.add('active');
+            const target = modal.querySelector(`#${btn.dataset.tab}`);
+            if (target) {
+              target.classList.add('active');
+            }
+          });
+        });
+
+        document.body.appendChild(modal);
       }
 
       // Disconnect
@@ -2013,12 +2681,20 @@
         this.cryptoKey = null;
         this.roomId = null;
         this.remoteUserId = null;
+        this.messageLog = [];
+        this.showEncrypted = false;
+        this.lastEncryptedHex = '';
+        this.renderChatMessages();
 
-        document.getElementById('chatMessages').innerHTML = '';
+        const encryptedToggle = document.getElementById('encryptedToggle');
+        if (encryptedToggle) {
+          encryptedToggle.classList.remove('active');
+        }
+
         document.getElementById('hostPassword').value = '';
         document.getElementById('joinPassword').value = '';
         document.getElementById('joinCode').value = '';
-        
+
         this.updateStatus('Disconnected', '');
         this.showWelcome();
       }


### PR DESCRIPTION
## Summary
- add encrypted and schema toggle buttons in the chat header with supporting styles for encrypted message previews
- rework message rendering to keep a local log so messages can be viewed in plaintext or encrypted form on demand
- introduce a data schema modal that visualizes recent events, state snapshots, and encryption settings

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68d2c13491988332a8e56c196b0bc182