### PR TITLE
Refactor crypto state management and message envelope handling

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -26,186 +26,373 @@ function ensureArrayBuffer(material) {
   throw new Error('Invalid key material');
 }
 
-async function deriveKey(password, salt) {
-  if (!password || !(salt instanceof Uint8Array)) {
-    throw new Error('Missing password or room salt');
+const CryptoManager = (() => {
+  const state = {
+    roomSalt: null,
+    baseKeyMaterial: null,
+    currentKey: null,
+    currentEpoch: 0,
+    fingerprint: '',
+    ecdhKeyPair: null
+  };
+
+  const listeners = new Set();
+
+  function emit(reason, details = {}) {
+    const snapshot = {
+      reason,
+      epoch: state.currentEpoch,
+      fingerprint: state.fingerprint,
+      hasKey: Boolean(state.currentKey),
+      roomSalt: state.roomSalt,
+      ...details
+    };
+
+    listeners.forEach((fn) => {
+      try {
+        fn(snapshot);
+      } catch (error) {
+        console.error('crypto:updated listener error', error);
+      }
+    });
   }
 
-  const encoder = new TextEncoder();
-  const keyMaterial = await crypto.subtle.importKey(
-    'raw',
-    encoder.encode(password),
-    'PBKDF2',
-    false,
-    ['deriveBits']
-  );
+  function ensureSaltSet() {
+    if (!(state.roomSalt instanceof Uint8Array)) {
+      throw new Error('Room salt not set');
+    }
+  }
 
-  const params = {
-    name: 'PBKDF2',
-    salt,
-    iterations: 100000,
-    hash: 'SHA-256'
-  };
+  function cloneSalt(bytes) {
+    if (!(bytes instanceof Uint8Array)) {
+      return null;
+    }
+    return new Uint8Array(bytes);
+  }
 
-  const derivedBits = await crypto.subtle.deriveBits(params, keyMaterial, 512);
-  const bytes = new Uint8Array(derivedBits);
-  const keyBytes = bytes.slice(0, 32);
-  const fingerprintBytes = bytes.slice(32, 48);
+  async function deriveKeyFromPassword(password, salt) {
+    if (!password || !(salt instanceof Uint8Array)) {
+      throw new Error('Missing password or room salt');
+    }
 
-  const cryptoKey = await crypto.subtle.importKey(
-    'raw',
-    keyBytes,
-    { name: 'AES-GCM', length: 256 },
-    false,
-    ['encrypt', 'decrypt']
-  );
+    const encoder = new TextEncoder();
+    const keyMaterial = await crypto.subtle.importKey(
+      'raw',
+      encoder.encode(password),
+      'PBKDF2',
+      false,
+      ['deriveBits']
+    );
 
-  return {
-    key: cryptoKey,
-    fingerprint: formatFingerprint(fingerprintBytes),
-    baseKeyMaterial: keyBytes.slice().buffer
-  };
-}
+    const params = {
+      name: 'PBKDF2',
+      salt,
+      iterations: 100000,
+      hash: 'SHA-256'
+    };
 
-async function encryptMessage(key, text) {
-  const iv = crypto.getRandomValues(new Uint8Array(12));
-  const encoded = new TextEncoder().encode(text);
-  const encrypted = await crypto.subtle.encrypt(
-    { name: 'AES-GCM', iv, tagLength: 128 },
-    key,
-    encoded
-  );
+    const derivedBits = await crypto.subtle.deriveBits(params, keyMaterial, 512);
+    const bytes = new Uint8Array(derivedBits);
+    const keyBytes = bytes.slice(0, 32);
+    const fingerprintBytes = bytes.slice(32, 48);
 
-  const combined = new Uint8Array(iv.length + encrypted.byteLength);
-  combined.set(iv);
-  combined.set(new Uint8Array(encrypted), iv.length);
-  return combined;
-}
+    const cryptoKey = await crypto.subtle.importKey(
+      'raw',
+      keyBytes,
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt', 'decrypt']
+    );
 
-async function decryptMessage(key, data) {
-  const iv = data.slice(0, 12);
-  const encrypted = data.slice(12);
+    return {
+      key: cryptoKey,
+      baseKeyMaterial: keyBytes.slice().buffer,
+      fingerprint: formatFingerprint(fingerprintBytes)
+    };
+  }
 
-  try {
+  async function encryptWithKey(key, text) {
+    if (!key) {
+      throw new Error('Encryption key unavailable');
+    }
+
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const encoded = new TextEncoder().encode(text);
+    const encrypted = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv, tagLength: 128 },
+      key,
+      encoded
+    );
+
+    const combined = new Uint8Array(iv.length + encrypted.byteLength);
+    combined.set(iv);
+    combined.set(new Uint8Array(encrypted), iv.length);
+    return combined;
+  }
+
+  async function decryptWithKey(key, data) {
+    if (!key) {
+      throw new Error('Decryption key unavailable');
+    }
+
+    const iv = data.slice(0, 12);
+    const encrypted = data.slice(12);
+
     const decrypted = await crypto.subtle.decrypt(
       { name: 'AES-GCM', iv, tagLength: 128 },
       key,
       encrypted
     );
     return new TextDecoder().decode(decrypted);
-  } catch (error) {
-    console.error('Message authentication failed:', error);
-    return null;
-  }
-}
-
-async function deriveRatchetKey(baseKey, epoch, salt) {
-  const material = ensureArrayBuffer(baseKey);
-
-  const hkdfKey = await crypto.subtle.importKey(
-    'raw',
-    material,
-    'HKDF',
-    false,
-    ['deriveBits']
-  );
-
-  const encoder = new TextEncoder();
-  const derivedBits = await crypto.subtle.deriveBits(
-    {
-      name: 'HKDF',
-      hash: 'SHA-256',
-      salt: salt instanceof Uint8Array ? salt : new Uint8Array(16),
-      info: encoder.encode(`epoch-${epoch}`)
-    },
-    hkdfKey,
-    256
-  );
-
-  return crypto.subtle.importKey(
-    'raw',
-    derivedBits,
-    { name: 'AES-GCM' },
-    false,
-    ['encrypt', 'decrypt']
-  );
-}
-
-async function generateECDHKeyPair() {
-  return crypto.subtle.generateKey(
-    {
-      name: 'ECDH',
-      namedCurve: 'P-256'
-    },
-    true,
-    ['deriveBits']
-  );
-}
-
-async function deriveSharedSecret(keyPair, peerPublicKeyBytes) {
-  if (!(peerPublicKeyBytes instanceof Uint8Array) || peerPublicKeyBytes.length === 0) {
-    throw new Error('Invalid peer public key');
   }
 
-  const peerPublicKey = await crypto.subtle.importKey(
-    'raw',
-    peerPublicKeyBytes,
-    {
-      name: 'ECDH',
-      namedCurve: 'P-256'
-    },
-    true,
-    []
-  );
+  async function deriveRatchetKey(baseKey, epoch, salt) {
+    const material = ensureArrayBuffer(baseKey);
 
-  const bits = await crypto.subtle.deriveBits(
-    {
-      name: 'ECDH',
-      public: peerPublicKey
-    },
-    keyPair.privateKey,
-    256
-  );
+    const hkdfKey = await crypto.subtle.importKey(
+      'raw',
+      material,
+      'HKDF',
+      false,
+      ['deriveBits']
+    );
 
-  return new Uint8Array(bits);
-}
+    const encoder = new TextEncoder();
+    const derivedBits = await crypto.subtle.deriveBits(
+      {
+        name: 'HKDF',
+        hash: 'SHA-256',
+        salt: salt instanceof Uint8Array ? salt : new Uint8Array(16),
+        info: encoder.encode(`epoch-${epoch}`)
+      },
+      hkdfKey,
+      256
+    );
 
-async function deriveSharedKey(sharedSecret, salt, info = 'secure-chat-ecdh') {
-  const hkdfKey = await crypto.subtle.importKey(
-    'raw',
-    sharedSecret,
-    'HKDF',
-    false,
-    ['deriveBits']
-  );
-
-  const encoder = new TextEncoder();
-  const derivedBits = await crypto.subtle.deriveBits(
-    {
-      name: 'HKDF',
-      hash: 'SHA-256',
-      salt,
-      info: encoder.encode(info)
-    },
-    hkdfKey,
-    256
-  );
-
-  const key = await crypto.subtle.importKey(
-    'raw',
-    derivedBits,
-    { name: 'AES-GCM' },
-    false,
-    ['encrypt', 'decrypt']
-  );
-
-  return { key, material: new Uint8Array(derivedBits) };
-}
-
-async function fingerprintFromMaterial(bytes) {
-  if (!(bytes instanceof Uint8Array)) {
-    return '';
+    return crypto.subtle.importKey(
+      'raw',
+      derivedBits,
+      { name: 'AES-GCM' },
+      false,
+      ['encrypt', 'decrypt']
+    );
   }
-  const digest = await crypto.subtle.digest('SHA-256', bytes);
-  return formatFingerprint(new Uint8Array(digest).slice(0, 16));
+
+  async function generateECDHKeyPair() {
+    return crypto.subtle.generateKey(
+      {
+        name: 'ECDH',
+        namedCurve: 'P-256'
+      },
+      true,
+      ['deriveBits']
+    );
+  }
+
+  async function deriveSharedSecret(keyPair, peerPublicKeyBytes) {
+    if (!(peerPublicKeyBytes instanceof Uint8Array) || peerPublicKeyBytes.length === 0) {
+      throw new Error('Invalid peer public key');
+    }
+
+    const peerPublicKey = await crypto.subtle.importKey(
+      'raw',
+      peerPublicKeyBytes,
+      {
+        name: 'ECDH',
+        namedCurve: 'P-256'
+      },
+      true,
+      []
+    );
+
+    const bits = await crypto.subtle.deriveBits(
+      {
+        name: 'ECDH',
+        public: peerPublicKey
+      },
+      keyPair.privateKey,
+      256
+    );
+
+    return new Uint8Array(bits);
+  }
+
+  async function deriveSharedKey(sharedSecret, salt, info = 'secure-chat-ecdh') {
+    const hkdfKey = await crypto.subtle.importKey(
+      'raw',
+      sharedSecret,
+      'HKDF',
+      false,
+      ['deriveBits']
+    );
+
+    const encoder = new TextEncoder();
+    const derivedBits = await crypto.subtle.deriveBits(
+      {
+        name: 'HKDF',
+        hash: 'SHA-256',
+        salt,
+        info: encoder.encode(info)
+      },
+      hkdfKey,
+      256
+    );
+
+    const key = await crypto.subtle.importKey(
+      'raw',
+      derivedBits,
+      { name: 'AES-GCM' },
+      false,
+      ['encrypt', 'decrypt']
+    );
+
+    return { key, material: new Uint8Array(derivedBits) };
+  }
+
+  async function fingerprintFromMaterial(bytes) {
+    if (!(bytes instanceof Uint8Array)) {
+      return '';
+    }
+    const digest = await crypto.subtle.digest('SHA-256', bytes);
+    return formatFingerprint(new Uint8Array(digest).slice(0, 16));
+  }
+
+  return {
+    setRoomSalt(bytes) {
+      state.roomSalt = cloneSalt(bytes);
+      emit('room-salt');
+      return state.roomSalt;
+    },
+
+    getRoomSalt() {
+      return cloneSalt(state.roomSalt);
+    },
+
+    async loadStaticKeyFromPassword(password) {
+      ensureSaltSet();
+      const result = await deriveKeyFromPassword(password, state.roomSalt);
+      state.baseKeyMaterial = result.baseKeyMaterial;
+      state.currentKey = result.key;
+      state.currentEpoch = 0;
+      state.fingerprint = result.fingerprint;
+      emit('static-key', { fingerprint: state.fingerprint });
+      return { key: state.currentKey, fingerprint: state.fingerprint };
+    },
+
+    async beginECDH() {
+      state.ecdhKeyPair = await generateECDHKeyPair();
+      emit('ecdh-begin');
+      return state.ecdhKeyPair;
+    },
+
+    async applyPeerECDH(peerPublicKeyBytes) {
+      if (!state.ecdhKeyPair) {
+        await this.beginECDH();
+      }
+      return deriveSharedSecret(state.ecdhKeyPair, peerPublicKeyBytes);
+    },
+
+    async promoteSharedSecret(sharedSecret) {
+      ensureSaltSet();
+      const { key, material } = await deriveSharedKey(sharedSecret, state.roomSalt, 'secure-chat-ecdh');
+      state.baseKeyMaterial = material.slice().buffer;
+      state.currentKey = key;
+      state.currentEpoch = 0;
+      state.fingerprint = await fingerprintFromMaterial(material);
+      emit('promote', { fingerprint: state.fingerprint });
+      return { key: state.currentKey, fingerprint: state.fingerprint };
+    },
+
+    async maybeRotate(epoch) {
+      if (!Number.isInteger(epoch) || epoch <= state.currentEpoch) {
+        return false;
+      }
+      if (!state.baseKeyMaterial) {
+        return false;
+      }
+
+      ensureSaltSet();
+      state.currentKey = await deriveRatchetKey(state.baseKeyMaterial, epoch, state.roomSalt);
+      state.currentEpoch = epoch;
+      emit('rotation', { epoch });
+      return true;
+    },
+
+    getCurrentKey() {
+      return state.currentKey;
+    },
+
+    getCurrentEpoch() {
+      return state.currentEpoch;
+    },
+
+    getFingerprint() {
+      return state.fingerprint;
+    },
+
+    hasBaseMaterial() {
+      return Boolean(state.baseKeyMaterial);
+    },
+
+    getECDHKeyPair() {
+      return state.ecdhKeyPair;
+    },
+
+    clearECDHKeyPair() {
+      state.ecdhKeyPair = null;
+      emit('ecdh-reset');
+    },
+
+    async encrypt(text) {
+      return encryptWithKey(state.currentKey, text);
+    },
+
+    async decrypt(data) {
+      try {
+        return await decryptWithKey(state.currentKey, data);
+      } catch (error) {
+        console.error('Message authentication failed:', error);
+        return null;
+      }
+    },
+
+    async encryptWithKey(key, text) {
+      return encryptWithKey(key, text);
+    },
+
+    async decryptWithKey(key, data) {
+      try {
+        return await decryptWithKey(key, data);
+      } catch (error) {
+        console.error('Message authentication failed:', error);
+        return null;
+      }
+    },
+
+    onUpdated(handler) {
+      if (typeof handler !== 'function') {
+        return () => {};
+      }
+      listeners.add(handler);
+      return () => {
+        listeners.delete(handler);
+      };
+    },
+
+    reset() {
+      state.baseKeyMaterial = null;
+      state.currentKey = null;
+      state.currentEpoch = 0;
+      state.fingerprint = '';
+      state.ecdhKeyPair = null;
+      state.roomSalt = null;
+      emit('reset');
+    }
+  };
+})();
+
+if (typeof window !== 'undefined') {
+  window.CryptoManager = CryptoManager;
+} else if (typeof self !== 'undefined') {
+  self.CryptoManager = CryptoManager;
 }

--- a/lib/net.js
+++ b/lib/net.js
@@ -1,3 +1,6 @@
+// never send raw JSON text; always envelope then encrypt
+// { kind: 'control'|'data', n?, sentAt?, control?: { type, ... }, data?: { text, ... } }
+
 function initPeer(app, id) {
   if (app.peer) {
     app.peer.destroy();
@@ -70,13 +73,10 @@ function initPeer(app, id) {
       if (password) {
         try {
           app.generateRoomSalt();
-          const keyData = await deriveKey(password, app.roomSalt);
-          app.cryptoKey = keyData.key;
-          app.baseKeyMaterial = keyData.baseKeyMaterial;
-          app.connectionFingerprint = keyData.fingerprint;
+          await CryptoManager.loadStaticKeyFromPassword(password);
           app.keyExchangeComplete = false;
           app.sentKeyExchange = false;
-          app.ecdhKeyPair = null;
+          CryptoManager.clearECDHKeyPair();
           app.resetMessageCounters();
           app.updateFingerprintDisplay(null);
         } catch (error) {
@@ -123,9 +123,10 @@ function setupConnection(app, conn) {
     app.updateStatus('Connected', 'connected');
     app.initHeartbeat();
     app.addSystemMessage('✅ Secure connection established!');
-    if (app.connectionFingerprint) {
-      app.updateFingerprintDisplay(app.connectionFingerprint);
-      app.addSystemMessage(`🔒 Verify code: ${app.connectionFingerprint}`);
+    const fingerprint = CryptoManager.getFingerprint();
+    if (fingerprint) {
+      app.updateFingerprintDisplay(fingerprint);
+      app.addSystemMessage(`🔒 Verify code: ${fingerprint}`);
     } else {
       app.updateFingerprintDisplay(null);
     }
@@ -171,7 +172,7 @@ function setupConnection(app, conn) {
       .map((b) => b.toString(16).padStart(2, '0'))
       .join('');
 
-    const decrypted = await decryptMessage(app.cryptoKey, payload);
+    const decrypted = await CryptoManager.decrypt(payload);
     if (!decrypted) {
       app.addSystemMessage('⚠️ Failed to decrypt message');
       return;
@@ -186,12 +187,25 @@ function setupConnection(app, conn) {
       return;
     }
 
-    if (await app.handleControlMessage(parsed)) {
+    if (!parsed || typeof parsed !== 'object') {
+      app.addSystemMessage('⚠️ Message integrity check failed. Ignoring message.');
+      return;
+    }
+
+    if (parsed.kind === 'control') {
+      if (await app.handleControlMessage(parsed.control || {}, parsed)) {
+        return;
+      }
+      return;
+    }
+
+    if (parsed.kind !== 'data') {
+      console.warn('Unsupported payload kind received:', parsed.kind);
       return;
     }
 
     const sequence = Number(parsed?.n);
-    const text = typeof parsed?.text === 'string' ? parsed.text : '';
+    const text = typeof parsed?.data?.text === 'string' ? parsed.data.text : '';
     const timestamp = typeof parsed?.sentAt === 'number' ? parsed.sentAt : Date.now();
 
     if (!Number.isInteger(sequence) || sequence < 1) {
@@ -232,19 +246,19 @@ function setupConnection(app, conn) {
     }
   });
 
-  activeConn.on('close', () => {
-    app.conn = null;
-    app.remoteUserId = null;
-    app.updateFingerprintDisplay(null);
-    app.resetMessageCounters();
-    app.stopHeartbeat();
-    app.keyExchangeComplete = false;
-    app.sentKeyExchange = false;
-    app.ecdhKeyPair = null;
-    if (app.isHost && app.currentShareLink) {
-      app.updateStatus('Waiting for peer...', 'connecting');
-      app.addSystemMessage('👋 Peer disconnected');
-      app.setWaitingBanner(true, app.currentShareLink, 'Your guest disconnected. Share the link to invite someone else.');
+    activeConn.on('close', () => {
+      app.conn = null;
+      app.remoteUserId = null;
+      app.updateFingerprintDisplay(null);
+      app.resetMessageCounters();
+      app.stopHeartbeat();
+      app.keyExchangeComplete = false;
+      app.sentKeyExchange = false;
+      CryptoManager.clearECDHKeyPair();
+      if (app.isHost && app.currentShareLink) {
+        app.updateStatus('Waiting for peer...', 'connecting');
+        app.addSystemMessage('👋 Peer disconnected');
+        app.setWaitingBanner(true, app.currentShareLink, 'Your guest disconnected. Share the link to invite someone else.');
     } else {
       app.updateStatus('Disconnected', '');
       app.addSystemMessage('👋 Peer disconnected');


### PR DESCRIPTION
## Summary
- centralize key management in a stateful CryptoManager that tracks salts, epochs, and emits crypto:updated events
- wrap outbound control and data payloads in a shared envelope and branch on the kind after decrypting once
- update the app to rely on CryptoManager for rotations, fingerprints, and control-plane messaging helpers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d2f2008804833286551bb23a65936f