### PR TITLE
Improve persistence verification and add connection safeguards

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -255,20 +255,41 @@ function setupConnection(app, conn) {
       app.keyExchangeComplete = false;
       app.sentKeyExchange = false;
       CryptoManager.clearECDHKeyPair();
-      if (app.isHost && app.currentShareLink) {
+      const systemMessage = '👋 Peer disconnected';
+      app.addSystemMessage(systemMessage);
+      if (typeof app.showToast === 'function') {
+        app.showToast(app.isHost ? 'Guest disconnected' : 'Disconnected from host', app.isHost ? 'warning' : 'error');
+      }
+      if (app.isHost) {
         app.updateStatus('Waiting for peer...', 'connecting');
-        app.addSystemMessage('👋 Peer disconnected');
-        app.setWaitingBanner(true, app.currentShareLink, 'Your guest disconnected. Share the link to invite someone else.');
-    } else {
-      app.updateStatus('Disconnected', '');
-      app.addSystemMessage('👋 Peer disconnected');
-    }
-  });
+        const waitingMessage = app.currentShareLink
+          ? 'Your guest disconnected. Share the link to invite someone else.'
+          : 'Your guest disconnected. Share the invite link when you are ready.';
+        const linkForBanner = app.currentShareLink || app.dom?.chatShareLink?.dataset?.link || '';
+        app.setWaitingBanner(true, linkForBanner, waitingMessage);
+      } else {
+        app.updateStatus('Disconnected', '');
+      }
+    });
 
   activeConn.on('error', (err) => {
     console.error('Connection error:', err);
     app.updateFingerprintDisplay(null);
     app.stopHeartbeat();
+    app.resetMessageCounters();
+    app.keyExchangeComplete = false;
+    app.sentKeyExchange = false;
+    CryptoManager.clearECDHKeyPair();
     app.addSystemMessage('⚠️ Connection error occurred');
+    if (typeof app.showToast === 'function') {
+      app.showToast('Connection error', 'error');
+    }
+    if (app.isHost) {
+      app.updateStatus('Waiting for peer...', 'connecting');
+      const linkForBanner = app.currentShareLink || app.dom?.chatShareLink?.dataset?.link || '';
+      app.setWaitingBanner(true, linkForBanner, 'Connection issue. Waiting for guest…');
+    } else {
+      app.updateStatus('Disconnected', '');
+    }
   });
 }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -8,6 +8,7 @@ class StorageManager {
         this.appliedSinceSnapshot = 0;
         this.storageKey = null;
         this.storageSalt = null;
+        this.lastVerification = null;
         this.ready = this.init();
       }
 
@@ -288,9 +289,9 @@ class StorageManager {
         }
       }
 
-      async rehydrate() {
+      async readLatestSnapshotRecord() {
         if (this.useMemory || !this.db) {
-          return;
+          return { snapshot: null, stateData: null };
         }
 
         let snapshot = null;
@@ -310,24 +311,44 @@ class StorageManager {
           console.warn('Failed to read snapshot.', error);
         }
 
-        if (snapshot?.state) {
+        if (!snapshot?.state) {
+          return { snapshot: snapshot || null, stateData: null };
+        }
+
+        try {
+          const stateData = snapshot.state?.encrypted
+            ? await this.decryptFromStorage(snapshot.state)
+            : snapshot.state;
+          return { snapshot, stateData };
+        } catch (error) {
+          console.warn('Failed to decrypt snapshot state. Falling back to event log.', error);
+          return { snapshot: null, stateData: null };
+        }
+      }
+
+      async rehydrate() {
+        if (this.useMemory || !this.db) {
+          return;
+        }
+
+        const { snapshot, stateData } = await this.readLatestSnapshotRecord();
+        const hasSnapshotState = Boolean(snapshot && stateData);
+
+        if (hasSnapshotState) {
           try {
-            const stateData = snapshot.state?.encrypted
-              ? await this.decryptFromStorage(snapshot.state)
-              : snapshot.state;
             this.state = reviveState(stateData);
           } catch (error) {
-            console.warn('Failed to decrypt snapshot state.', error);
+            console.warn('Failed to revive snapshot state. Replaying full event log.', error);
             this.state = new ChatState();
           }
         } else {
           this.state = new ChatState();
         }
 
-        const after = snapshot?.at ?? 0;
+        const replayAfter = hasSnapshotState ? (snapshot?.at ?? 0) : 0;
         let events = [];
         try {
-          events = await this.loadEventsAfter(after);
+          events = await this.loadEventsAfter(replayAfter);
         } catch (error) {
           console.warn('Failed to load events.', error);
           events = [];
@@ -370,6 +391,162 @@ class StorageManager {
         });
       }
 
+      async countEvents() {
+        if (this.useMemory) {
+          return this.eventsBuffer.length;
+        }
+
+        if (!this.db) {
+          return 0;
+        }
+
+        return new Promise((resolve) => {
+          try {
+            const tx = this.db.transaction('events', 'readonly');
+            const store = tx.objectStore('events');
+            const request = store.count();
+            request.onsuccess = () => resolve(request.result || 0);
+            request.onerror = () => resolve(0);
+          } catch (error) {
+            console.warn('Failed to count events.', error);
+            resolve(0);
+          }
+        });
+      }
+
+      summarizeState(state) {
+        if (!(state instanceof ChatState)) {
+          return {
+            rooms: 0,
+            messages: 0,
+            byRoom: 0,
+            reactions: 0
+          };
+        }
+
+        return {
+          rooms: state.rooms instanceof Map ? state.rooms.size : 0,
+          messages: state.messages instanceof Map ? state.messages.size : 0,
+          byRoom: state.byRoom instanceof Map ? state.byRoom.size : 0,
+          reactions: state.reactions instanceof Map ? state.reactions.size : 0
+        };
+      }
+
+      summarizeRawState(raw) {
+        if (!raw || typeof raw !== 'object') {
+          return {
+            rooms: 0,
+            messages: 0,
+            byRoom: 0,
+            reactions: 0
+          };
+        }
+
+        return {
+          rooms: Array.isArray(raw.rooms) ? raw.rooms.length : 0,
+          messages: Array.isArray(raw.messages) ? raw.messages.length : 0,
+          byRoom: Array.isArray(raw.byRoom) ? raw.byRoom.length : 0,
+          reactions: Array.isArray(raw.reactions) ? raw.reactions.length : 0
+        };
+      }
+
+      async verify() {
+        try {
+          await this.ready;
+        } catch (error) {
+          console.warn('Storage not ready for verification.', error);
+          this.lastVerification = { ok: false, error: 'init-failed' };
+          return false;
+        }
+
+        if (this.useMemory) {
+          const tempState = new ChatState();
+          const events = (this.eventsBuffer || []).filter(Boolean).sort((a, b) => (a.at || 0) - (b.at || 0));
+          for (const event of events) {
+            reduce(tempState, event);
+          }
+
+          const replayCounts = this.summarizeState(tempState);
+          const currentCounts = this.summarizeState(this.state);
+          const ok = ['rooms', 'messages', 'byRoom', 'reactions'].every((key) => replayCounts[key] === currentCounts[key]);
+
+          this.lastVerification = {
+            ok,
+            snapshotAt: null,
+            snapshotEventCount: null,
+            eventsReplayed: events.length,
+            totalEvents: events.length,
+            snapshotCounts: { rooms: 0, messages: 0, byRoom: 0, reactions: 0 },
+            replayCounts,
+            currentCounts,
+            mismatches: ok ? [] : ['state-divergence'],
+            mode: 'memory'
+          };
+
+          return ok;
+        }
+
+        const { snapshot, stateData } = await this.readLatestSnapshotRecord();
+        const hasSnapshotState = Boolean(snapshot && stateData);
+        const baseRaw = stateData || null;
+        const snapshotCounts = this.summarizeRawState(baseRaw);
+        const verificationState = reviveState(baseRaw);
+        const replayAfter = hasSnapshotState ? (snapshot?.at ?? 0) : 0;
+
+        let events = [];
+        try {
+          events = await this.loadEventsAfter(replayAfter);
+        } catch (error) {
+          console.warn('Failed to load events for verification.', error);
+          events = [];
+        }
+
+        events = (events || []).filter(Boolean);
+        events.sort((a, b) => (a.at || 0) - (b.at || 0));
+        for (const event of events) {
+          reduce(verificationState, event);
+        }
+
+        const replayCounts = this.summarizeState(verificationState);
+        const currentCounts = this.summarizeState(this.state);
+        const totalEvents = await this.countEvents();
+
+        const snapshotEventCount = typeof snapshot?.eventCountAtSnapshot === 'number'
+          ? snapshot.eventCountAtSnapshot
+          : null;
+
+        const mismatches = [];
+        ['rooms', 'messages', 'byRoom', 'reactions'].forEach((key) => {
+          if (replayCounts[key] !== currentCounts[key]) {
+            mismatches.push(key);
+          }
+        });
+
+        if (snapshotEventCount !== null && Number.isFinite(totalEvents)) {
+          const expectedEvents = snapshotEventCount + events.length;
+          if (expectedEvents !== totalEvents) {
+            mismatches.push('eventCount');
+          }
+        }
+
+        const ok = mismatches.length === 0;
+
+        this.lastVerification = {
+          ok,
+          snapshotAt: hasSnapshotState ? snapshot.at : null,
+          snapshotEventCount,
+          eventsReplayed: events.length,
+          totalEvents: Number.isFinite(totalEvents) ? totalEvents : null,
+          snapshotCounts,
+          replayCounts,
+          currentCounts,
+          mismatches,
+          mode: 'persistent'
+        };
+
+        return ok;
+      }
+
       async apply(event, { persist = true } = {}) {
         if (!event) {
           return;
@@ -403,10 +580,17 @@ class StorageManager {
         }
 
         const rawState = serializeState(this.state);
+        let eventCountAtSnapshot = 0;
+        try {
+          eventCountAtSnapshot = await this.countEvents();
+        } catch (error) {
+          eventCountAtSnapshot = 0;
+        }
         const snapshot = {
           id: generateId('snap-'),
           at: Date.now(),
-          state: this.storageKey ? await this.encryptForStorage(rawState) : rawState
+          state: this.storageKey ? await this.encryptForStorage(rawState) : rawState,
+          eventCountAtSnapshot
         };
 
         await new Promise((resolve, reject) => {

--- a/styles.css
+++ b/styles.css
@@ -104,6 +104,50 @@
       gap: 0.5rem;
     }
 
+    .toast-container {
+      position: fixed;
+      top: 1.5rem;
+      right: 1.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      z-index: 2000;
+      pointer-events: none;
+    }
+
+    .toast {
+      min-width: 220px;
+      max-width: 320px;
+      background: rgba(26, 26, 26, 0.95);
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      color: var(--text-primary);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 20px 50px rgba(0, 0, 0, 0.6);
+      transform: translateY(-12px);
+      opacity: 0;
+      transition: opacity 0.25s ease, transform 0.25s ease;
+      font-size: 0.9rem;
+      pointer-events: auto;
+    }
+
+    .toast.visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .toast-info {
+      border-left: 3px solid var(--accent);
+    }
+
+    .toast-warning {
+      border-left: 3px solid var(--warning);
+    }
+
+    .toast-error {
+      border-left: 3px solid var(--error);
+    }
+
     .connection-badge {
       padding: 0.5rem 1rem;
       background: var(--bg-tertiary);
@@ -793,6 +837,8 @@
       margin-bottom: 2rem;
       padding-bottom: 1rem;
       border-bottom: 1px solid var(--border);
+      gap: 1rem;
+      flex-wrap: wrap;
     }
 
     .schema-header button {
@@ -807,6 +853,44 @@
 
     .schema-header button:hover {
       background: #333;
+    }
+
+    .schema-status {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .schema-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-size: 0.8rem;
+      padding: 0.35rem 0.75rem;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.05);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      color: var(--text-secondary);
+    }
+
+    .schema-badge.ok {
+      color: var(--success);
+      border-color: rgba(0, 214, 143, 0.4);
+    }
+
+    .schema-badge.error {
+      color: var(--error);
+      border-color: rgba(255, 59, 48, 0.4);
+    }
+
+    .schema-badge.pending {
+      color: var(--text-secondary);
+    }
+
+    .schema-summary {
+      color: var(--text-secondary);
+      font-size: 0.75rem;
     }
 
     .schema-section {


### PR DESCRIPTION
## Summary
- track event counts in snapshots, add a verification replay pass, and harden rehydration fallback logic in storage
- expose verification status inside the schema viewer (with a dev-only `#schema` route) and surface a badge for pass/fail
- add toast-backed UX for rate limits, buffer backpressure, and connection closure/error handling, including styles for the new notifications

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68d2f97937d08332928e7269718b388d