### PR TITLE
Implement secure invite flow with one-time seats

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,36 +90,33 @@
             Loading...
           </div>
           
-          <div class="input-group">
-            <label class="input-label">Set Encryption Password</label>
-            <input type="password" id="hostPassword" class="input-field" placeholder="Choose a strong password">
-          </div>
-          
           <button class="btn btn-primary" style="width: 100%;" onclick="App.startHost()">
-            Start Secure Room
+            Generate Secure Invite
           </button>
-          
+
           <div id="shareSection" class="share-section" style="display: none;">
-            <p class="share-note">📤 Share this invite link with your guest. Send the password using a different channel.</p>
-            <div class="share-link" id="shareLink" onclick="App.copyShareLink()" role="button" tabindex="0" aria-label="Copy invite link">
-              Generating link...
-            </div>
-            <button class="btn btn-primary" style="width: 100%; margin-bottom: 1rem;" onclick="App.copyShareLink()">📋 Copy Link</button>
+            <div class="invite-section" id="inviteSection">
+              <h3>🎟️ Secure One-Time Invite</h3>
+              <p>This link works only once and expires in 15 minutes.</p>
 
-            <div class="salt-section">
-              <div class="salt-label">Room Salt (safe to share)</div>
-              <div class="share-link" id="roomSaltDisplay" onclick="App.copyRoomSalt()" role="button" tabindex="0" aria-label="Copy room salt">
-                Generating salt...
+              <div class="invite-link-container">
+                <input id="inviteLink" class="invite-input" readonly value="Generating secure link..." aria-live="polite">
+                <button id="copyInviteBtn" class="btn btn-primary">📋 Copy Secure Link</button>
               </div>
-              <div class="input-hint">The salt is also included in the invite link for convenience.</div>
-              <button class="btn btn-secondary" style="width: 100%;" onclick="App.copyRoomSalt()">📋 Copy Salt</button>
-            </div>
 
-            <div class="simple-setup">
-              <label class="input-label" for="simpleEmail">Simple setup (optional)</label>
-              <input type="email" id="simpleEmail" class="input-field" placeholder="Invite email (leave blank to use device share)">
-              <button class="btn btn-secondary" style="width: 100%;" onclick="App.simpleShareInvite()">✨ Simple Setup: Share Invite</button>
-              <div id="simpleShareStatus" class="simple-status"></div>
+              <div class="security-info">
+                ✅ No passwords needed<br>
+                ✅ Single-use only<br>
+                ✅ Auto-expires<br>
+                ✅ Cryptographically secure
+              </div>
+
+              <div class="simple-setup">
+                <label class="input-label" for="simpleEmail">Simple setup (optional)</label>
+                <input type="email" id="simpleEmail" class="input-field" placeholder="Invite email (leave blank to use device share)">
+                <button class="btn btn-secondary" style="width: 100%;" onclick="App.simpleShareInvite()">✨ Simple Setup: Share Invite</button>
+                <div id="simpleShareStatus" class="simple-status"></div>
+              </div>
             </div>
           </div>
           
@@ -135,28 +132,13 @@
       <div class="setup-screen">
         <div class="setup-card">
           <h2>Join Secure Room</h2>
-          <p style="color: var(--text-secondary); text-align: center; margin-bottom: 1rem;">Enter the room details shared with you</p>
-          
-          <div class="input-group">
-            <label class="input-label">Room Code</label>
-            <input type="text" id="joinCode" class="input-field" placeholder="Paste the shared room code">
-          </div>
+          <p style="color: var(--text-secondary); text-align: center; margin-bottom: 1rem;">Use the secure invite link sent to you</p>
 
-          <div class="input-group">
-            <label class="input-label">Encryption Password</label>
-            <input type="password" id="joinPassword" class="input-field" placeholder="Enter shared password">
-            <div class="input-hint">Verify this password over a different channel.</div>
+          <div class="joining-status">
+            <div class="spinner" id="joinSpinner"></div>
+            <p id="joinStatus" tabindex="-1">Claiming your secure seat...</p>
+            <p class="small" id="joinStatusDetail">Verifying one-time token...</p>
           </div>
-
-          <div class="input-group">
-            <label class="input-label">Room Salt</label>
-            <input type="text" id="joinSalt" class="input-field" placeholder="Paste the room salt or open the invite link">
-            <div class="input-hint">The invite link fills this automatically. Salt can be shared publicly.</div>
-          </div>
-          
-          <button class="btn btn-primary" style="width: 100%;" onclick="App.startJoin()">
-            Join Room
-          </button>
           
           <button class="btn btn-secondary" style="width: 100%; margin-top: 1rem;" onclick="App.showWelcome()">
             Back

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -3,6 +3,355 @@ const FINGERPRINT_ANIMALS = ['Falcon', 'Tiger', 'Wolf', 'Otter', 'Eagle', 'Panth
 const FINGERPRINT_NUMBERS = ['Zero', 'One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight', 'Nine', 'Ten', 'Eleven', 'Twelve', 'Thirteen', 'Fourteen', 'Fifteen'];
 const FINGERPRINT_PLACES = ['Harbor', 'Mountain', 'Forest', 'River', 'Canyon', 'Desert', 'Valley', 'Grove', 'Summit', 'Lagoon', 'Prairie', 'Temple', 'Island', 'Village', 'Tundra', 'Meadow', 'Fjord', 'Citadel', 'Bridge', 'Monolith'];
 
+function toBase64Url(bytes) {
+  if (!(bytes instanceof Uint8Array)) {
+    return '';
+  }
+  let base64;
+  if (typeof btoa === 'function') {
+    let binary = '';
+    bytes.forEach((b) => {
+      binary += String.fromCharCode(b);
+    });
+    base64 = btoa(binary);
+  } else if (typeof Buffer !== 'undefined') {
+    base64 = Buffer.from(bytes).toString('base64');
+  } else {
+    throw new Error('Base64 encoding unavailable');
+  }
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function fromBase64Url(value) {
+  if (typeof value !== 'string' || !value.trim()) {
+    return null;
+  }
+  let normalized = value.trim();
+  normalized = normalized.replace(/-/g, '+').replace(/_/g, '/');
+  while (normalized.length % 4 !== 0) {
+    normalized += '=';
+  }
+  try {
+    if (typeof atob === 'function') {
+      const binary = atob(normalized);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i += 1) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+      return bytes;
+    }
+    if (typeof Buffer !== 'undefined') {
+      return new Uint8Array(Buffer.from(normalized, 'base64'));
+    }
+  } catch (error) {
+    return null;
+  }
+  return null;
+}
+
+class SecureInvite {
+  static async generateSeat(ttlMs = 15 * 60 * 1000) {
+    if (!crypto?.getRandomValues) {
+      throw new Error('Secure random source unavailable');
+    }
+
+    const keyMaterial = crypto.getRandomValues(new Uint8Array(32));
+    const seatToken = crypto.getRandomValues(new Uint8Array(16));
+
+    return {
+      seatId: toBase64Url(seatToken),
+      secretKey: toBase64Url(keyMaterial),
+      claimed: false,
+      expiresAt: Date.now() + ttlMs
+    };
+  }
+
+  static toBase64Url(bytes) {
+    return toBase64Url(bytes);
+  }
+
+  static fromBase64Url(value) {
+    return fromBase64Url(value);
+  }
+
+  static async deriveSeatKey(secretKey, seatId) {
+    const secretBytes = fromBase64Url(secretKey);
+    const seatBytes = fromBase64Url(seatId);
+
+    if (!(secretBytes instanceof Uint8Array) || secretBytes.length !== 32) {
+      throw new Error('Invalid seat secret material');
+    }
+
+    if (!(seatBytes instanceof Uint8Array) || seatBytes.length === 0) {
+      throw new Error('Invalid seat identifier');
+    }
+
+    const hkdfKey = await crypto.subtle.importKey(
+      'raw',
+      secretBytes,
+      'HKDF',
+      false,
+      ['deriveBits']
+    );
+
+    const derivedBits = await crypto.subtle.deriveBits(
+      {
+        name: 'HKDF',
+        hash: 'SHA-256',
+        salt: seatBytes,
+        info: new TextEncoder().encode('secure-seat-material')
+      },
+      hkdfKey,
+      512
+    );
+
+    const bytes = new Uint8Array(derivedBits);
+    const keyBytes = bytes.slice(0, 32);
+    const fingerprintBytes = bytes.slice(32, 48);
+
+    const cryptoKey = await crypto.subtle.importKey(
+      'raw',
+      keyBytes,
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt', 'decrypt']
+    );
+
+    return {
+      key: cryptoKey,
+      baseKeyMaterial: keyBytes.slice().buffer,
+      fingerprint: formatFingerprint(fingerprintBytes)
+    };
+  }
+
+  static async signInvite(roomId, seatId, secretKey, expiresAt) {
+    if (!roomId || !seatId || !secretKey) {
+      throw new Error('Missing invite parameters');
+    }
+
+    const secretBytes = fromBase64Url(secretKey);
+    if (!(secretBytes instanceof Uint8Array)) {
+      throw new Error('Invalid seat secret');
+    }
+
+    const key = await crypto.subtle.importKey(
+      'raw',
+      secretBytes,
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['sign']
+    );
+
+    const payload = `${roomId}.${seatId}.${expiresAt || 0}`;
+    const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payload));
+    return toBase64Url(new Uint8Array(signature));
+  }
+
+  static async verifyInviteSignature(invite) {
+    if (!invite?.roomId || !invite?.seatId || !invite?.secretKey || !invite?.signature) {
+      return false;
+    }
+
+    try {
+      const expected = await SecureInvite.signInvite(
+        invite.roomId,
+        invite.seatId,
+        invite.secretKey,
+        invite.expiresAt
+      );
+      return expected === invite.signature;
+    } catch (error) {
+      console.warn('Failed to verify invite signature.', error);
+      return false;
+    }
+  }
+
+  static encodePayload(payload) {
+    if (!payload) {
+      return '';
+    }
+    const json = JSON.stringify(payload);
+    const bytes = new TextEncoder().encode(json);
+    return toBase64Url(bytes);
+  }
+
+  static decodePayload(encoded) {
+    if (typeof encoded !== 'string' || !encoded.trim()) {
+      return null;
+    }
+
+    const bytes = fromBase64Url(encoded);
+    if (!(bytes instanceof Uint8Array)) {
+      return null;
+    }
+
+    try {
+      const json = new TextDecoder().decode(bytes);
+      return JSON.parse(json);
+    } catch (error) {
+      console.warn('Unable to decode invite payload.', error);
+      return null;
+    }
+  }
+}
+
+class InviteManager {
+  constructor() {
+    this.usedInvites = new Set();
+    this.db = null;
+    this.ready = this.init();
+  }
+
+  async init() {
+    if (typeof indexedDB === 'undefined') {
+      return;
+    }
+
+    try {
+      this.db = await this.openDB();
+      await this.loadUsedInvites();
+    } catch (error) {
+      console.warn('InviteManager falling back to memory store.', error);
+      this.db = null;
+    }
+  }
+
+  openDB() {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open('secure-chat-invites', 1);
+
+      request.onupgradeneeded = (event) => {
+        const db = event.target.result;
+        if (!db.objectStoreNames.contains('claimed')) {
+          db.createObjectStore('claimed', { keyPath: 'token' });
+        }
+      };
+
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  async loadUsedInvites() {
+    if (!this.db) {
+      return;
+    }
+
+    await new Promise((resolve, reject) => {
+      const transaction = this.db.transaction('claimed', 'readonly');
+      const store = transaction.objectStore('claimed');
+      const request = store.openCursor();
+
+      request.onsuccess = (event) => {
+        const cursor = event.target.result;
+        if (cursor) {
+          const { token, expiresAt } = cursor.value || {};
+          if (expiresAt && expiresAt < Date.now()) {
+            this.deleteToken(token).catch(() => {});
+          } else if (token) {
+            this.usedInvites.add(token);
+          }
+          cursor.continue();
+        }
+      };
+
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
+  async deleteToken(token) {
+    if (!token || !this.db) {
+      return;
+    }
+
+    await new Promise((resolve, reject) => {
+      const transaction = this.db.transaction('claimed', 'readwrite');
+      const store = transaction.objectStore('claimed');
+      store.delete(token);
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
+  async isClaimed(token) {
+    if (!token) {
+      return false;
+    }
+
+    if (this.usedInvites.has(token)) {
+      return true;
+    }
+
+    if (!this.db) {
+      return false;
+    }
+
+    return new Promise((resolve) => {
+      const transaction = this.db.transaction('claimed', 'readonly');
+      const store = transaction.objectStore('claimed');
+      const request = store.get(token);
+      request.onsuccess = () => {
+        const record = request.result;
+        if (record?.expiresAt && record.expiresAt < Date.now()) {
+          this.deleteToken(token).catch(() => {});
+          resolve(false);
+          return;
+        }
+        resolve(Boolean(record));
+      };
+      request.onerror = () => resolve(false);
+    });
+  }
+
+  async markClaimed(token, expiresAt = 0) {
+    if (!token) {
+      return;
+    }
+    this.usedInvites.add(token);
+
+    if (!this.db) {
+      return;
+    }
+
+    await new Promise((resolve, reject) => {
+      const transaction = this.db.transaction('claimed', 'readwrite');
+      const store = transaction.objectStore('claimed');
+      store.put({ token, expiresAt });
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
+  async validateInvite(invite) {
+    const roomId = invite?.roomId;
+    const seatId = invite?.seatId;
+    const expiresAt = invite?.expiresAt;
+    const secretKey = invite?.secretKey;
+    const signature = invite?.signature;
+
+    if (!roomId || !seatId || !secretKey) {
+      throw new Error('Incomplete invite payload');
+    }
+
+    if (typeof expiresAt === 'number' && expiresAt < Date.now()) {
+      throw new Error('Invite has expired');
+    }
+
+    if (!signature || !(await SecureInvite.verifyInviteSignature(invite))) {
+      throw new Error('Invalid invite signature');
+    }
+
+    const token = `${roomId}.${seatId}`;
+    if (await this.isClaimed(token)) {
+      throw new Error('Invite already claimed');
+    }
+
+    await this.markClaimed(token, expiresAt || 0);
+    return true;
+  }
+}
+
 function formatFingerprint(bytes) {
   if (!(bytes instanceof Uint8Array) || bytes.length === 0) {
     return '';
@@ -279,6 +628,17 @@ const CryptoManager = (() => {
       return { key: state.currentKey, fingerprint: state.fingerprint };
     },
 
+    async loadStaticKeyFromSeat(secretKey, seatId) {
+      ensureSaltSet();
+      const result = await SecureInvite.deriveSeatKey(secretKey, seatId);
+      state.baseKeyMaterial = result.baseKeyMaterial.slice(0);
+      state.currentKey = result.key;
+      state.currentEpoch = 0;
+      state.fingerprint = result.fingerprint;
+      emit('static-key', { fingerprint: state.fingerprint });
+      return { key: state.currentKey, fingerprint: state.fingerprint };
+    },
+
     async beginECDH() {
       state.ecdhKeyPair = await generateECDHKeyPair();
       emit('ecdh-begin');
@@ -393,8 +753,12 @@ const CryptoManager = (() => {
 
 if (typeof window !== 'undefined') {
   window.CryptoManager = CryptoManager;
+  window.SecureInvite = SecureInvite;
+  window.InviteManager = InviteManager;
 } else if (typeof self !== 'undefined') {
   self.CryptoManager = CryptoManager;
+  self.SecureInvite = SecureInvite;
+  self.InviteManager = InviteManager;
 }
 
 if (typeof module !== 'undefined' && module.exports) {
@@ -409,6 +773,10 @@ if (typeof module !== 'undefined' && module.exports) {
     generateECDHKeyPair,
     deriveSharedSecret,
     deriveSharedKey,
-    fingerprintFromMaterial
+    fingerprintFromMaterial,
+    SecureInvite,
+    InviteManager,
+    toBase64Url,
+    fromBase64Url
   };
 }

--- a/lib/net.js
+++ b/lib/net.js
@@ -40,6 +40,15 @@ function initPeer(app, id) {
       app.addSystemMessage('Peer is connecting...');
       app.updateStatus('Peer connecting...', 'connecting');
       app.setWaitingBanner(true, app.currentShareLink, 'Someone is connecting...');
+      if (app.seats?.guest?.claimed) {
+        app.addSystemMessage('⚠️ Rejecting connection attempt - invite already claimed.');
+        try {
+          conn.close();
+        } catch (error) {
+          console.warn('Failed to close duplicate connection.', error);
+        }
+        return;
+      }
       setupConnection(app, conn);
     });
   }
@@ -72,33 +81,38 @@ function initPeer(app, id) {
         app.resetConversationState();
       }
 
-      const password = app.dom.hostPassword?.value;
-      if (password) {
-        try {
-          app.generateRoomSalt();
-          await CryptoManager.loadStaticKeyFromPassword(password);
-          app.keyExchangeComplete = false;
-          app.sentKeyExchange = false;
-          CryptoManager.clearECDHKeyPair();
-          app.resetMessageCounters();
-          app.updateFingerprintDisplay(null);
-        } catch (error) {
-          console.error('Failed to refresh room secrets after ID collision.', error);
-          app.addSystemMessage('⚠️ Unable to refresh room security details. Please recreate the room.');
-          app.disconnect();
-          return;
+      try {
+        const [hostSeat, guestSeat] = await Promise.all([
+          SecureInvite.generateSeat(),
+          SecureInvite.generateSeat()
+        ]);
+        app.seats = { host: hostSeat, guest: guestSeat };
+        const seatSalt = SecureInvite.fromBase64Url(guestSeat.seatId);
+        if (!(seatSalt instanceof Uint8Array)) {
+          throw new Error('Invalid regenerated seat');
         }
-
-        const shareLink = app.generateShareLink(app.roomId);
-        if (app.dom.shareLink) {
-          app.dom.shareLink.textContent = shareLink;
-          app.dom.shareLink.dataset.link = shareLink;
-        }
+        CryptoManager.setRoomSalt(seatSalt);
+        app.roomSalt = CryptoManager.getRoomSalt();
+        app.roomSaltBase64 = app.bytesToBase64(app.roomSalt);
+        await CryptoManager.loadStaticKeyFromSeat(guestSeat.secretKey, guestSeat.seatId);
+        await app.inviteManagerReady;
+        const hostToken = `${app.roomId}.${hostSeat.seatId}`;
+        app.inviteManager?.markClaimed(hostToken, hostSeat.expiresAt).catch(() => {});
+        app.keyExchangeComplete = false;
+        app.sentKeyExchange = false;
+        CryptoManager.clearECDHKeyPair();
+        app.resetMessageCounters();
+        app.updateFingerprintDisplay(null);
+        const shareLink = await app.generateShareLink(app.roomId, guestSeat);
+        app.updateInviteLink(shareLink);
         app.currentShareLink = shareLink;
-        app.setWaitingBanner(true, shareLink, 'Share this link and send the password separately to your guest.');
-      } else {
-        app.currentShareLink = '';
-        app.setWaitingBanner(false, '');
+        app.updateSimpleShareStatus('');
+        app.setWaitingBanner(true, shareLink, 'Share this one-time secure link with your guest.');
+      } catch (error) {
+        console.error('Failed to refresh room secrets after ID collision.', error);
+        app.addSystemMessage('⚠️ Unable to refresh room security details. Please recreate the room.');
+        app.disconnect();
+        return;
       }
 
       app.addSystemMessage(`Room ID was taken, new room: ${app.roomId}`);
@@ -126,6 +140,16 @@ function setupConnection(app, conn) {
     app.updateStatus('Connected', 'connected');
     app.initHeartbeat();
     app.addSystemMessage('✅ Secure connection established!');
+    if (app.isHost && app.seats?.guest) {
+      app.seats.guest.claimed = true;
+      try {
+        await app.inviteManagerReady;
+        const token = `${app.roomId}.${app.seats.guest.seatId}`;
+        app.inviteManager?.markClaimed(token, app.seats.guest.expiresAt).catch(() => {});
+      } catch (error) {
+        console.warn('Unable to persist guest invite claim.', error);
+      }
+    }
     const fingerprint = CryptoManager.getFingerprint();
     if (fingerprint) {
       app.updateFingerprintDisplay(fingerprint);
@@ -262,31 +286,33 @@ function setupConnection(app, conn) {
     }
   });
 
-    activeConn.on('close', () => {
-      app.conn = null;
-      app.remoteUserId = null;
-      app.updateFingerprintDisplay(null);
-      app.resetMessageCounters();
-      app.stopHeartbeat();
-      app.keyExchangeComplete = false;
-      app.sentKeyExchange = false;
-      CryptoManager.clearECDHKeyPair();
-      const systemMessage = '👋 Peer disconnected';
-      app.addSystemMessage(systemMessage);
-      if (typeof app.showToast === 'function') {
-        app.showToast(app.isHost ? 'Guest disconnected' : 'Disconnected from host', app.isHost ? 'warning' : 'error');
+  activeConn.on('close', async () => {
+    app.conn = null;
+    app.remoteUserId = null;
+    app.updateFingerprintDisplay(null);
+    app.resetMessageCounters();
+    app.stopHeartbeat();
+    app.keyExchangeComplete = false;
+    app.sentKeyExchange = false;
+    CryptoManager.clearECDHKeyPair();
+    const systemMessage = '👋 Peer disconnected';
+    app.addSystemMessage(systemMessage);
+    if (typeof app.showToast === 'function') {
+      app.showToast(app.isHost ? 'Guest disconnected' : 'Disconnected from host', app.isHost ? 'warning' : 'error');
+    }
+    if (app.isHost) {
+      app.updateStatus('Waiting for peer...', 'connecting');
+      const link = await app.refreshGuestInvite({
+        bannerMessage: 'Your guest disconnected. Share this new one-time link to invite someone else.',
+        announce: true
+      });
+      if (!link) {
+        app.setWaitingBanner(false, '', 'Unable to generate a new invite automatically.');
       }
-      if (app.isHost) {
-        app.updateStatus('Waiting for peer...', 'connecting');
-        const waitingMessage = app.currentShareLink
-          ? 'Your guest disconnected. Share the link to invite someone else.'
-          : 'Your guest disconnected. Share the invite link when you are ready.';
-        const linkForBanner = app.currentShareLink || app.dom?.chatShareLink?.dataset?.link || '';
-        app.setWaitingBanner(true, linkForBanner, waitingMessage);
-      } else {
-        app.updateStatus('Disconnected', '');
-      }
-    });
+    } else {
+      app.updateStatus('Disconnected', '');
+    }
+  });
 
   activeConn.on('error', (err) => {
     console.error('Connection error:', err);

--- a/styles.css
+++ b/styles.css
@@ -426,51 +426,46 @@
       border: 1px solid rgba(0, 102, 255, 0.3);
     }
 
-    .share-note {
-      font-size: 0.875rem;
-      color: var(--text-secondary);
-      margin-bottom: 0.75rem;
-      line-height: 1.4;
-    }
-
-    .share-link {
-      background: var(--bg-primary);
-      padding: 1rem;
-      border-radius: 8px;
-      word-break: break-all;
-      font-size: 0.75rem;
-      font-family: monospace;
-      cursor: pointer;
-      margin: 0.75rem 0;
-    }
-
-    .share-link:hover {
-      background: var(--bg-secondary);
-    }
-
-    .salt-section {
-      margin-top: 1rem;
-      padding: 1rem;
-      background: rgba(0, 0, 0, 0.2);
-      border-radius: 12px;
-      border: 1px dashed rgba(0, 102, 255, 0.4);
+    .invite-section {
       display: flex;
       flex-direction: column;
-      gap: 0.5rem;
+      gap: 1rem;
     }
 
-    .salt-label {
-      font-size: 0.8rem;
-      color: var(--text-secondary);
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
+    .invite-section h3 {
+      margin: 0;
+      font-size: 1.25rem;
+      font-weight: 600;
     }
 
-    .input-hint {
-      font-size: 0.75rem;
+    .invite-link-container {
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+    }
+
+    .invite-input {
+      flex: 1;
+      padding: 0.85rem;
+      background: var(--bg-primary);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      color: var(--text-primary);
+      font-family: monospace;
+      font-size: 0.85rem;
+      min-height: 3rem;
+    }
+
+    .invite-input:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(0, 102, 255, 0.1);
+    }
+
+    .security-info {
+      font-size: 0.85rem;
       color: var(--text-secondary);
-      margin-top: 0.5rem;
-      line-height: 1.4;
+      line-height: 1.6;
     }
 
     .simple-setup {
@@ -491,6 +486,39 @@
 
     .simple-status.error {
       color: var(--error);
+    }
+
+    .joining-status {
+      margin-top: 1rem;
+      padding: 1.5rem;
+      border-radius: 12px;
+      background: rgba(0, 0, 0, 0.25);
+      border: 1px solid rgba(0, 102, 255, 0.2);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.75rem;
+      text-align: center;
+    }
+
+    .joining-status .spinner {
+      width: 32px;
+      height: 32px;
+      border: 3px solid rgba(255, 255, 255, 0.2);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 0.9s linear infinite;
+    }
+
+    .joining-status .small {
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+    }
+
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
+      }
     }
 
     /* Chat Interface */


### PR DESCRIPTION
## Summary
- replace the password-based setup with one-time secure invite seats and automatic key derivation
- refresh the host and join flows to consume invite payloads, regenerate links, and block reuse after claim
- update UI styling to highlight one-time invites and expand crypto tests to cover invite signing

## Testing
- node tests/crypto.spec.js

------
https://chatgpt.com/codex/tasks/task_b_68d455ffaa8c83329b106b45ed9d5850