### PR TITLE
Add persistent room identities and member sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,57 +150,115 @@
     <!-- Chat Screen -->
     <div id="chatScreen" class="screen">
       <div class="chat-container">
-        <div class="chat-header">
-          <div class="chat-room-info">
-            <span>🔐</span>
-            <div class="room-badge" id="currentRoom">xxx-xxx-xxx</div>
-          </div>
-          <div class="view-toggles">
-            <button id="encryptedToggle" class="toggle-btn" onclick="App.toggleEncryptedView()" aria-pressed="false">
-              <span>🔍</span>
-              Encrypted View
+        <div class="chat-main">
+          <div class="chat-header">
+            <div class="chat-room-info">
+              <span>🔐</span>
+              <div class="room-badge" id="currentRoom">xxx-xxx-xxx</div>
+            </div>
+            <div class="view-toggles">
+              <button id="encryptedToggle" class="toggle-btn" onclick="App.toggleEncryptedView()" aria-pressed="false">
+                <span>🔍</span>
+                Encrypted View
+              </button>
+              <button id="schemaToggle" class="toggle-btn" onclick="App.showSchemaView()">
+                <span>📊</span>
+                Data Schema
+              </button>
+            </div>
+            <button class="btn btn-secondary" style="padding: 0.5rem 1rem;" onclick="App.disconnect()">
+              Leave
             </button>
-            <button id="schemaToggle" class="toggle-btn" onclick="App.showSchemaView()">
-              <span>📊</span>
-              Data Schema
-            </button>
           </div>
-          <button class="btn btn-secondary" style="padding: 0.5rem 1rem;" onclick="App.disconnect()">
-            Leave
-          </button>
-        </div>
 
-        <div id="waitingBanner" class="waiting-banner" role="status" aria-live="polite">
-          <div class="waiting-icon">⏳</div>
-          <div class="waiting-details">
-            <div class="waiting-title">Waiting for your guest</div>
-            <div id="waitingMessage" class="waiting-subtitle">Share the invite link below to bring someone into this secure room.</div>
-            <div class="waiting-link-row">
-              <div id="chatShareLink" class="chat-share-link" onclick="App.copyShareLink('chatShareLink')" role="button" tabindex="0" aria-label="Copy chat invite link">
-                Generating link...
+          <div id="waitingBanner" class="waiting-banner" role="status" aria-live="polite">
+            <div class="waiting-icon">⏳</div>
+            <div class="waiting-details">
+              <div class="waiting-title">Waiting for your guest</div>
+              <div id="waitingMessage" class="waiting-subtitle">Share the invite link below to bring someone into this secure room.</div>
+              <div class="waiting-link-row">
+                <div id="chatShareLink" class="chat-share-link" onclick="App.copyShareLink('chatShareLink')" role="button" tabindex="0" aria-label="Copy chat invite link">
+                  Generating link...
+                </div>
+                <button id="chatCopyLink" class="btn btn-secondary" onclick="App.copyShareLink('chatShareLink')" disabled>
+                  📋 Copy Link
+                </button>
               </div>
-              <button id="chatCopyLink" class="btn btn-secondary" onclick="App.copyShareLink('chatShareLink')" disabled>
-                📋 Copy Link
+            </div>
+          </div>
+
+          <div id="systemAnnouncements" class="sr-only" aria-live="polite" aria-atomic="false"></div>
+          <div id="chatMessages" class="chat-messages" role="log" aria-live="polite">
+            <!-- Messages will appear here -->
+          </div>
+
+          <div class="chat-input-container">
+            <div class="chat-input-wrapper">
+              <input type="text" id="messageInput" class="chat-input" placeholder="Type a secure message...">
+              <button id="sendBtn" class="send-btn">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <line x1="22" y1="2" x2="11" y2="13"></line>
+                  <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+                </svg>
               </button>
             </div>
           </div>
         </div>
+        <aside id="memberSidebar" class="members-sidebar" aria-label="Room members"></aside>
+      </div>
 
-        <div id="systemAnnouncements" class="sr-only" aria-live="polite" aria-atomic="false"></div>
-        <div id="chatMessages" class="chat-messages" role="log" aria-live="polite">
-          <!-- Messages will appear here -->
-        </div>
-
-        <div class="chat-input-container">
-          <div class="chat-input-wrapper">
-            <input type="text" id="messageInput" class="chat-input" placeholder="Type a secure message...">
-            <button id="sendBtn" class="send-btn">
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <line x1="22" y1="2" x2="11" y2="13"></line>
-                <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
-              </svg>
-            </button>
+      <div id="identityModal" class="identity-modal" role="dialog" aria-modal="true" aria-labelledby="identityModalTitle" hidden>
+        <div class="identity-dialog">
+          <div class="identity-header">
+            <h3 id="identityModalTitle">Choose Your Identity</h3>
+            <p id="identityModalSubtitle">Secure your seat in this room</p>
           </div>
+
+          <div id="identityModeCreate" class="identity-section">
+            <form id="identityCreateForm" novalidate>
+              <div class="identity-block">
+                <h4>Display Name</h4>
+                <p class="help-text">Pick a generated name or create your own</p>
+                <div id="identitySuggestions" class="name-suggestions"></div>
+                <div class="custom-name-option">
+                  <input type="text" id="identityNameInput" maxlength="30" placeholder="Or type your own…" autocomplete="off">
+                  <button type="button" id="identityRefreshBtn" class="refresh-btn">🎲 New suggestions</button>
+                </div>
+              </div>
+
+              <div class="identity-block">
+                <h4>Password</h4>
+                <p class="help-text">Create a password to rejoin this room later</p>
+                <div class="password-input-group">
+                  <input type="password" id="identityPasswordInput" placeholder="Create room password" autocomplete="new-password" required>
+                  <div class="password-strength">
+                    <div id="identityStrengthBar" class="strength-bar" data-strength="0"></div>
+                    <span id="identityStrengthText" class="strength-text">Choose a strong password</span>
+                  </div>
+                </div>
+              </div>
+
+              <div class="identity-actions">
+                <button type="submit" class="btn btn-primary" id="identitySubmitBtn">Join Secure Room</button>
+              </div>
+            </form>
+          </div>
+
+          <div id="identityModeReturning" class="identity-section" hidden>
+            <form id="identityReturningForm" novalidate>
+              <div class="identity-block">
+                <h4>Welcome Back</h4>
+                <p class="help-text">Enter your password to rejoin as <strong id="identityHint">You</strong></p>
+                <input type="password" id="identityReturningPassword" placeholder="Enter your room password" autocomplete="current-password" required>
+              </div>
+              <div class="identity-actions">
+                <button type="submit" class="btn btn-primary">Rejoin Room</button>
+                <button type="button" class="btn btn-secondary" id="identityUseNew">Join as someone new</button>
+              </div>
+            </form>
+          </div>
+
+          <div id="identityError" class="identity-error" role="alert" aria-live="assertive" hidden></div>
         </div>
       </div>
     </div>
@@ -209,6 +267,7 @@
   <!-- Load PeerJS -->
   <script src="https://unpkg.com/peerjs@1.5.1/dist/peerjs.min.js"></script>
 
+  <script src="lib/identity.js"></script>
     <script src="lib/events.js"></script>
   <script src="lib/state.js"></script>
   <script src="lib/storage.js"></script>

--- a/lib/identity.js
+++ b/lib/identity.js
@@ -1,0 +1,480 @@
+class SecureNameGenerator {
+  constructor() {
+    this.adjectives = [
+      'Azure', 'Crimson', 'Emerald', 'Golden', 'Silver', 'Violet', 'Amber', 'Jade',
+      'Swift', 'Bright', 'Clever', 'Noble', 'Brave', 'Calm', 'Bold', 'Wise',
+      'Storm', 'River', 'Mountain', 'Ocean', 'Forest', 'Desert', 'Thunder', 'Winter',
+      'Cosmic', 'Stellar', 'Lunar', 'Solar', 'Nebula', 'Astral', 'Orbital', 'Quantum'
+    ];
+
+    this.nouns = [
+      'Eagle', 'Wolf', 'Fox', 'Hawk', 'Lion', 'Tiger', 'Bear', 'Falcon',
+      'Phoenix', 'Dragon', 'Griffin', 'Sphinx', 'Hydra', 'Pegasus', 'Kraken', 'Titan',
+      'Shield', 'Compass', 'Beacon', 'Arrow', 'Blade', 'Crown', 'Torch', 'Prism',
+      'Guardian', 'Explorer', 'Scholar', 'Ranger', 'Knight', 'Sage', 'Pioneer', 'Nomad'
+    ];
+  }
+
+  generate(options = {}) {
+    const { includeNumber = true, separator = '-', capitalize = true } = options;
+
+    if (!window?.crypto?.getRandomValues) {
+      const fallback = `${this.randomChoice(this.adjectives)}${separator}${this.randomChoice(this.nouns)}`;
+      return includeNumber ? `${fallback}${separator}${Math.floor(Math.random() * 900 + 100)}` : fallback;
+    }
+
+    const adj = this.randomWord(this.adjectives, capitalize);
+    const noun = this.randomWord(this.nouns, capitalize);
+
+    const number = includeNumber
+      ? (crypto.getRandomValues(new Uint32Array(1))[0] % 900) + 100
+      : null;
+
+    const parts = [adj, noun];
+    if (includeNumber && Number.isInteger(number)) {
+      parts.push(String(number));
+    }
+
+    return parts.join(separator);
+  }
+
+  generateMultiple(count = 5, options = {}) {
+    const names = new Set();
+    while (names.size < count) {
+      names.add(this.generate(options));
+    }
+    return Array.from(names);
+  }
+
+  randomWord(list, capitalize) {
+    const word = this.randomChoice(list);
+    if (!capitalize) {
+      return word.toLowerCase();
+    }
+    return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+  }
+
+  randomChoice(list) {
+    if (!Array.isArray(list) || list.length === 0) {
+      return '';
+    }
+
+    if (window?.crypto?.getRandomValues) {
+      const index = crypto.getRandomValues(new Uint32Array(1))[0] % list.length;
+      return list[index];
+    }
+
+    const index = Math.floor(Math.random() * list.length);
+    return list[index];
+  }
+}
+
+class SecureRoomStorage {
+  constructor(namespace = 'secure-room-identity') {
+    this.namespace = namespace;
+  }
+
+  async saveRoomIdentity(roomId, payload) {
+    if (!roomId || !payload) {
+      return;
+    }
+    try {
+      localStorage.setItem(this.key(roomId), JSON.stringify(payload));
+    } catch (error) {
+      console.warn('Unable to persist room identity.', error);
+    }
+  }
+
+  async getRoomIdentity(roomId) {
+    if (!roomId) {
+      return null;
+    }
+    try {
+      const stored = localStorage.getItem(this.key(roomId));
+      if (!stored) {
+        return null;
+      }
+      return JSON.parse(stored);
+    } catch (error) {
+      console.warn('Unable to read room identity.', error);
+      return null;
+    }
+  }
+
+  async clearRoomIdentity(roomId) {
+    try {
+      localStorage.removeItem(this.key(roomId));
+    } catch (error) {
+      console.warn('Unable to clear room identity.', error);
+    }
+  }
+
+  key(roomId) {
+    return `${this.namespace}:${roomId}`;
+  }
+}
+
+class RoomIdentity {
+  constructor(roomId) {
+    if (!roomId) {
+      throw new Error('Room ID required to manage identity');
+    }
+
+    this.roomId = roomId;
+    this.storage = new SecureRoomStorage();
+  }
+
+  async createIdentity(displayName, password) {
+    if (!displayName || typeof displayName !== 'string') {
+      throw new Error('Display name required');
+    }
+    if (!password || password.length < 4) {
+      throw new Error('Password required');
+    }
+    if (!window?.crypto?.subtle) {
+      throw new Error('WebCrypto unavailable for identity creation');
+    }
+
+    const salt = crypto.getRandomValues(new Uint8Array(32));
+    const keyMaterial = await this.getKeyMaterial(password);
+    const roomKey = await this.deriveKey(keyMaterial, salt, ['encrypt', 'decrypt']);
+
+    const identity = {
+      id: typeof crypto.randomUUID === 'function'
+        ? crypto.randomUUID()
+        : `id-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      displayName,
+      avatar: this.generateAvatar(displayName),
+      created: Date.now(),
+      publicKey: await this.generatePublicKey(),
+      lastSeen: Date.now()
+    };
+
+    const encryptedIdentity = await this.encrypt(identity, roomKey);
+    await this.storage.saveRoomIdentity(this.roomId, {
+      encrypted: encryptedIdentity,
+      salt: this.toBase64(salt),
+      hint: `${displayName.slice(0, 3)}***`
+    });
+
+    return identity;
+  }
+
+  async verifyReturningMember(password) {
+    if (!window?.crypto?.subtle) {
+      throw new Error('WebCrypto unavailable for identity verification');
+    }
+
+    const stored = await this.storage.getRoomIdentity(this.roomId);
+    if (!stored) {
+      return null;
+    }
+
+    if (!password || typeof password !== 'string') {
+      throw new Error('Password required to decrypt identity');
+    }
+
+    const keyMaterial = await this.getKeyMaterial(password);
+    const salt = this.fromBase64(stored.salt);
+    const roomKey = await this.deriveKey(keyMaterial, salt, ['decrypt']);
+
+    const identity = await this.decrypt(stored.encrypted, roomKey);
+    identity.lastSeen = Date.now();
+    return identity;
+  }
+
+  async getKeyMaterial(password) {
+    const encoder = new TextEncoder();
+    return crypto.subtle.importKey(
+      'raw',
+      encoder.encode(password),
+      'PBKDF2',
+      false,
+      ['deriveBits', 'deriveKey']
+    );
+  }
+
+  async deriveKey(keyMaterial, salt, usages) {
+    const key = await crypto.subtle.deriveKey(
+      {
+        name: 'PBKDF2',
+        salt,
+        iterations: 150000,
+        hash: 'SHA-256'
+      },
+      keyMaterial,
+      { name: 'AES-GCM', length: 256 },
+      false,
+      usages
+    );
+    return key;
+  }
+
+  async encrypt(data, key) {
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const encoded = new TextEncoder().encode(JSON.stringify(data));
+    const encrypted = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, encoded);
+    return {
+      iv: this.toBase64(iv),
+      data: this.toBase64(new Uint8Array(encrypted))
+    };
+  }
+
+  async decrypt(payload, key) {
+    if (!payload?.iv || !payload?.data) {
+      throw new Error('Invalid encrypted identity payload');
+    }
+    const iv = this.fromBase64(payload.iv);
+    const data = this.fromBase64(payload.data);
+    const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
+    const decoder = new TextDecoder();
+    return JSON.parse(decoder.decode(decrypted));
+  }
+
+  async generatePublicKey() {
+    try {
+      const keyPair = await crypto.subtle.generateKey(
+        {
+          name: 'ECDSA',
+          namedCurve: 'P-256'
+        },
+        true,
+        ['sign', 'verify']
+      );
+      const exported = await crypto.subtle.exportKey('spki', keyPair.publicKey);
+      return this.toBase64(new Uint8Array(exported));
+    } catch (error) {
+      console.warn('Failed to create identity key pair.', error);
+      return null;
+    }
+  }
+
+  generateAvatar(name) {
+    const emojis = ['🦊', '🦁', '🐺', '🦅', '🐉', '🦉', '🐯', '🦜', '🦋', '🐠'];
+    const colors = ['#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7', '#DDA0DD'];
+    const hash = this.hashString(name);
+    const emoji = emojis[hash % emojis.length];
+    const color = colors[Math.floor(hash / emojis.length) % colors.length];
+    return { emoji, color };
+  }
+
+  hashString(str) {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      hash = (hash << 5) - hash + str.charCodeAt(i);
+      hash |= 0;
+    }
+    return Math.abs(hash);
+  }
+
+  toBase64(bytes) {
+    if (!(bytes instanceof Uint8Array)) {
+      return '';
+    }
+    let binary = '';
+    for (let i = 0; i < bytes.byteLength; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary);
+  }
+
+  fromBase64(b64) {
+    if (!b64 || typeof b64 !== 'string') {
+      return new Uint8Array();
+    }
+    const binary = atob(b64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+}
+
+class RoomMembers {
+  constructor(rootElement) {
+    this.rootElement = rootElement || null;
+    this.members = new Map();
+    this.presenceTimeout = 30000;
+    this.refreshInterval = null;
+    this.ensureRefresh();
+    this.render();
+  }
+
+  ensureRefresh() {
+    if (this.refreshInterval) {
+      return;
+    }
+    this.refreshInterval = setInterval(() => this.render(), 10000);
+  }
+
+  dispose() {
+    if (this.refreshInterval) {
+      clearInterval(this.refreshInterval);
+      this.refreshInterval = null;
+    }
+    this.members.clear();
+    this.render();
+  }
+
+  upsertMember(identity, options = {}) {
+    if (!identity?.id) {
+      return;
+    }
+
+    const existing = this.members.get(identity.id) || {};
+    const now = Date.now();
+    const member = {
+      id: identity.id,
+      displayName: identity.displayName || existing.displayName || 'Member',
+      avatar: identity.avatar || existing.avatar || { emoji: '🙂', color: '#4A9FD5' },
+      publicKey: identity.publicKey || existing.publicKey || null,
+      isHost: options.isHost ?? existing.isHost ?? false,
+      verified: options.verified ?? existing.verified ?? false,
+      online: options.online ?? existing.online ?? false,
+      lastSeen: options.lastSeen ?? existing.lastSeen ?? now
+    };
+
+    if (member.online) {
+      member.lastSeen = now;
+    }
+
+    this.members.set(member.id, member);
+    this.render();
+  }
+
+  markOffline(memberId) {
+    const member = this.members.get(memberId);
+    if (!member) {
+      return;
+    }
+    member.online = false;
+    member.lastSeen = Date.now();
+    this.members.set(memberId, member);
+    this.render();
+  }
+
+  markOnline(memberId) {
+    const member = this.members.get(memberId);
+    if (!member) {
+      return;
+    }
+    member.online = true;
+    member.lastSeen = Date.now();
+    this.members.set(memberId, member);
+    this.render();
+  }
+
+  updatePresence(memberId) {
+    const member = this.members.get(memberId);
+    if (!member) {
+      return;
+    }
+    member.lastSeen = Date.now();
+    member.online = true;
+    this.members.set(memberId, member);
+    this.render();
+  }
+
+  removeMember(memberId) {
+    if (this.members.delete(memberId)) {
+      this.render();
+    }
+  }
+
+  render() {
+    if (!this.rootElement) {
+      return;
+    }
+
+    const members = Array.from(this.members.values()).sort((a, b) => {
+      if (a.isHost && !b.isHost) return -1;
+      if (!a.isHost && b.isHost) return 1;
+      return a.displayName.localeCompare(b.displayName);
+    });
+
+    const markup = `
+      <div class="members-sidebar-inner">
+        <div class="members-header">
+          <span class="member-count">${members.length}</span>
+          <span>Room Members</span>
+        </div>
+        <div class="members-list">
+          ${members
+            .map((member) => this.renderMember(member))
+            .join('')}
+        </div>
+        <div class="members-footer">
+          <div class="encryption-status">🔐 All messages end-to-end encrypted</div>
+        </div>
+      </div>
+    `;
+
+    this.rootElement.innerHTML = markup;
+  }
+
+  renderMember(member) {
+    const statusClass = member.online ? 'online' : 'offline';
+    const statusText = member.online
+      ? 'Active'
+      : `Last seen ${this.formatTime(member.lastSeen)}`;
+    const badge = [member.isHost ? '👑' : '', member.verified ? '✓' : '']
+      .filter(Boolean)
+      .join(' ');
+
+    const avatarColor = member.avatar?.color || '#4A9FD5';
+    const avatarEmoji = member.avatar?.emoji || '🙂';
+
+    return `
+      <div class="member-item" data-id="${member.id}">
+        <div class="member-avatar" style="--avatar-color: ${avatarColor}; background: ${avatarColor};">
+          ${avatarEmoji}
+        </div>
+        <div class="member-info">
+          <div class="member-name">${this.escapeHtml(member.displayName)}</div>
+          <div class="member-status">
+            <span class="status-dot ${statusClass}"></span>
+            ${statusText}
+          </div>
+        </div>
+        <div class="member-badge">${badge}</div>
+      </div>
+    `;
+  }
+
+  formatTime(timestamp) {
+    if (!timestamp) {
+      return 'recently';
+    }
+    const diff = Date.now() - timestamp;
+    if (diff < 60000) {
+      return 'just now';
+    }
+    if (diff < 3600000) {
+      const minutes = Math.max(1, Math.floor(diff / 60000));
+      return `${minutes} min ago`;
+    }
+    const hours = Math.max(1, Math.floor(diff / 3600000));
+    if (hours < 24) {
+      return `${hours} hr ago`;
+    }
+    const days = Math.floor(diff / 86400000);
+    return `${days} day${days === 1 ? '' : 's'} ago`;
+  }
+
+  escapeHtml(value) {
+    if (typeof value !== 'string') {
+      return '';
+    }
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+}
+
+window.SecureNameGenerator = SecureNameGenerator;
+window.RoomIdentity = RoomIdentity;
+window.RoomMembers = RoomMembers;

--- a/lib/net.js
+++ b/lib/net.js
@@ -140,6 +140,9 @@ function setupConnection(app, conn) {
     app.updateStatus('Connected', 'connected');
     app.initHeartbeat();
     app.addSystemMessage('✅ Secure connection established!');
+    if (app.localIdentity?.id) {
+      app.roomMembers?.markOnline(app.localIdentity.id);
+    }
     if (app.isHost && app.seats?.guest) {
       app.seats.guest.claimed = true;
       try {
@@ -169,6 +172,7 @@ function setupConnection(app, conn) {
     await app.persistRoom();
 
     await app.startKeyExchange();
+    app.scheduleIdentityAnnouncement(true);
   });
 
   activeConn.on('data', async (data) => {
@@ -289,12 +293,14 @@ function setupConnection(app, conn) {
   activeConn.on('close', async () => {
     app.conn = null;
     app.remoteUserId = null;
+    app.markRemoteOffline();
     app.updateFingerprintDisplay(null);
     app.resetMessageCounters();
     app.stopHeartbeat();
     app.keyExchangeComplete = false;
     app.sentKeyExchange = false;
     CryptoManager.clearECDHKeyPair();
+    app.clearIdentityAnnouncement();
     const systemMessage = '👋 Peer disconnected';
     app.addSystemMessage(systemMessage);
     if (typeof app.showToast === 'function') {
@@ -322,6 +328,8 @@ function setupConnection(app, conn) {
     app.keyExchangeComplete = false;
     app.sentKeyExchange = false;
     CryptoManager.clearECDHKeyPair();
+    app.markRemoteOffline();
+    app.clearIdentityAnnouncement();
     app.addSystemMessage('⚠️ Connection error occurred');
     if (typeof app.showToast === 'function') {
       app.showToast('Connection error', 'error');

--- a/styles.css
+++ b/styles.css
@@ -524,9 +524,15 @@
     /* Chat Interface */
     .chat-container {
       height: 100%;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 280px;
+      background: var(--bg-primary);
+    }
+
+    .chat-main {
       display: flex;
       flex-direction: column;
-      background: var(--bg-primary);
+      min-height: 0;
     }
 
     .chat-header {
@@ -835,6 +841,343 @@
       cursor: not-allowed;
     }
 
+    .members-sidebar {
+      background: #2c2d30;
+      border-left: 1px solid #1a1b1d;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+    }
+
+    .members-sidebar-inner {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    .members-header {
+      padding: 16px;
+      border-bottom: 1px solid #1a1b1d;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      color: #fff;
+      font-weight: 600;
+    }
+
+    .member-count {
+      background: #4a9fd5;
+      padding: 2px 8px;
+      border-radius: 12px;
+      font-size: 12px;
+    }
+
+    .members-list {
+      flex: 1;
+      overflow-y: auto;
+      padding: 8px 0;
+    }
+
+    .member-item {
+      display: flex;
+      align-items: center;
+      padding: 8px 16px;
+      gap: 12px;
+      cursor: pointer;
+      transition: background 0.2s ease;
+    }
+
+    .member-item:hover {
+      background: rgba(255, 255, 255, 0.05);
+    }
+
+    .member-avatar {
+      width: 36px;
+      height: 36px;
+      border-radius: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 20px;
+      background: var(--avatar-color, #4a9fd5);
+    }
+
+    .member-info {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .member-name {
+      color: #fff;
+      font-size: 14px;
+      font-weight: 500;
+    }
+
+    .members-sidebar .status-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      margin-right: 0;
+    }
+
+    .members-sidebar .status-dot.online {
+      background: #44b700;
+      box-shadow: 0 0 0 2px rgba(68, 183, 0, 0.2);
+      border: none;
+    }
+
+    .members-sidebar .status-dot.offline {
+      background: transparent;
+      border: 2px solid #a0a0a2;
+    }
+
+    .member-status {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 12px;
+      color: #a0a0a2;
+    }
+
+    .member-badge {
+      margin-left: auto;
+      color: #fff;
+      font-size: 14px;
+    }
+
+    .members-footer {
+      padding: 16px;
+      border-top: 1px solid #1a1b1d;
+      color: #a0a0a2;
+      font-size: 12px;
+      text-align: center;
+    }
+
+    .identity-modal {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.75);
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      z-index: 2000;
+    }
+
+    .identity-modal[hidden] {
+      display: none;
+    }
+
+    .identity-dialog {
+      background: #101114;
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      border-radius: 16px;
+      width: min(520px, 100%);
+      padding: 2rem;
+      color: #fff;
+      box-shadow: 0 24px 60px rgba(0, 0, 0, 0.4);
+    }
+
+    .identity-header {
+      margin-bottom: 1.5rem;
+    }
+
+    .identity-header h3 {
+      margin: 0;
+      font-size: 1.5rem;
+    }
+
+    .identity-header p {
+      margin: 0.5rem 0 0;
+      color: #9da3b0;
+      font-size: 0.95rem;
+    }
+
+    .identity-section {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    .identity-block {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .identity-block h4 {
+      margin: 0;
+      font-size: 1rem;
+    }
+
+    .identity-block .help-text {
+      margin: 0;
+      color: #9da3b0;
+      font-size: 0.9rem;
+    }
+
+    .name-suggestions {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 0.75rem;
+    }
+
+    .name-option {
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      background: rgba(255, 255, 255, 0.04);
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      text-align: left;
+      color: #fff;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      cursor: pointer;
+      transition: border 0.2s ease, transform 0.2s ease;
+      width: 100%;
+      outline: none;
+    }
+
+    .name-option:hover,
+    .name-option.selected {
+      border-color: var(--accent);
+      transform: translateY(-1px);
+    }
+
+    .name-option:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+
+    .name-option .name-avatar {
+      width: 36px;
+      height: 36px;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 20px;
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    .custom-name-option {
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+    }
+
+    .custom-name-option input {
+      flex: 1;
+      padding: 0.75rem 1rem;
+      border-radius: 10px;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.05);
+      color: #fff;
+      font-size: 0.95rem;
+    }
+
+    .custom-name-option input::placeholder {
+      color: rgba(255, 255, 255, 0.5);
+    }
+
+    .refresh-btn {
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 8px;
+      padding: 0.75rem 1rem;
+      color: #fff;
+      cursor: pointer;
+      font-size: 0.9rem;
+      transition: background 0.2s ease;
+    }
+
+    .refresh-btn:hover {
+      background: rgba(255, 255, 255, 0.12);
+    }
+
+    .password-input-group {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .password-input-group input {
+      padding: 0.9rem 1rem;
+      border-radius: 10px;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.05);
+      color: #fff;
+    }
+
+    .password-strength {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .strength-bar {
+      height: 6px;
+      flex: 1;
+      background: rgba(255, 255, 255, 0.1);
+      border-radius: 4px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .strength-bar::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      transform-origin: left;
+      transform: scaleX(0.15);
+      background: #f87171;
+      transition: transform 0.3s ease, background 0.3s ease;
+    }
+
+    .strength-bar[data-strength="1"]::after {
+      transform: scaleX(0.3);
+      background: #f87171;
+    }
+
+    .strength-bar[data-strength="2"]::after {
+      transform: scaleX(0.6);
+      background: #fbbf24;
+    }
+
+    .strength-bar[data-strength="3"]::after {
+      transform: scaleX(0.85);
+      background: #34d399;
+    }
+
+    .strength-bar[data-strength="4"]::after {
+      transform: scaleX(1);
+      background: #22c55e;
+    }
+
+    .strength-text {
+      color: #9da3b0;
+      font-size: 0.85rem;
+    }
+
+    .identity-actions {
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+    }
+
+    .identity-error {
+      margin-top: 1rem;
+      padding: 0.75rem 1rem;
+      border-radius: 10px;
+      background: rgba(248, 113, 113, 0.12);
+      border: 1px solid rgba(248, 113, 113, 0.4);
+      color: #fecaca;
+      font-size: 0.9rem;
+    }
+
     .schema-modal {
       position: fixed;
       top: 0;
@@ -1086,6 +1429,19 @@
     @media (max-width: 768px) {
       .welcome-card, .setup-card {
         padding: 2rem 1.5rem;
+      }
+
+      .chat-container {
+        grid-template-columns: 1fr;
+      }
+
+      .members-sidebar {
+        display: none;
+      }
+
+      .identity-dialog {
+        width: min(420px, 100%);
+        padding: 1.5rem;
       }
 
       .welcome h1 {


### PR DESCRIPTION
## Summary
- add SecureNameGenerator, RoomIdentity, and RoomMembers helpers for managing per-room identities and presence
- redesign the chat layout to include a member sidebar and identity creation modal
- integrate identity exchange and presence updates into the chat workflow and connection handling

## Testing
- node tests/crypto.spec.js

------
https://chatgpt.com/codex/tasks/task_b_68d45c6e27a08332a21082795679df55