### PR TITLE
Add interactive identity name selector

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1290,47 +1290,118 @@
     }
 
     .name-suggestions {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-      gap: 0.75rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
     }
 
-    .name-option {
-      border: 1px solid rgba(255, 255, 255, 0.08);
+    .name-selector-card {
       background: rgba(255, 255, 255, 0.04);
-      border-radius: 12px;
-      padding: 0.75rem 1rem;
-      text-align: left;
-      color: #fff;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 16px;
+      padding: 1.25rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+      transition: border 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .name-selector-card[data-state='selected'] {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 1px rgba(0, 102, 255, 0.3);
+    }
+
+    .current-name-display {
       display: flex;
       align-items: center;
-      gap: 0.75rem;
-      cursor: pointer;
-      transition: border 0.2s ease, transform 0.2s ease;
-      width: 100%;
-      outline: none;
+      gap: 1rem;
     }
 
-    .name-option:hover,
-    .name-option.selected {
-      border-color: var(--accent);
-      transform: translateY(-1px);
-    }
-
-    .name-option:focus-visible {
-      outline: 2px solid var(--accent);
-      outline-offset: 2px;
-    }
-
-    .name-option .name-avatar {
-      width: 36px;
-      height: 36px;
-      border-radius: 8px;
+    .avatar-preview {
+      width: 56px;
+      height: 56px;
+      border-radius: 14px;
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 20px;
+      font-size: 1.75rem;
+      color: rgba(0, 0, 0, 0.8);
       background: rgba(255, 255, 255, 0.08);
+    }
+
+    .name-preview h2 {
+      margin: 0;
+      color: var(--text-primary);
+      font-size: 1.25rem;
+      letter-spacing: 0.01em;
+    }
+
+    .name-preview .name-type {
+      display: inline-block;
+      margin-top: 0.15rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+    }
+
+    .name-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .name-actions .btn {
+      flex: 1 1 160px;
+      justify-content: center;
+    }
+
+    .name-actions .btn-text {
+      flex: 0 0 auto;
+      align-self: center;
+    }
+
+    .btn-text {
+      background: none;
+      border: none;
+      color: var(--text-secondary);
+      font-size: 0.95rem;
+      font-weight: 500;
+      cursor: pointer;
+      text-decoration: underline;
+      padding: 0.25rem 0.5rem;
+      transition: color 0.2s ease;
+    }
+
+    .btn-text:hover,
+    .btn-text:focus-visible {
+      color: var(--accent);
+      outline: none;
+    }
+
+    .rejected-names {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .rejected-pill {
+      background: rgba(255, 255, 255, 0.05);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      color: var(--text-secondary);
+      border-radius: 999px;
+      padding: 0.35rem 0.75rem;
+      font-size: 0.85rem;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    }
+
+    .rejected-pill:hover,
+    .rejected-pill:focus-visible {
+      background: rgba(255, 255, 255, 0.12);
+      border-color: var(--accent);
+      color: var(--text-primary);
+      outline: none;
     }
 
     .custom-name-option {


### PR DESCRIPTION
## Summary
- replace the static grid of identity name buttons with a stateful selector card that supports accepting, regenerating, and revisiting suggestions
- integrate the new selector with the existing create identity flow, including join button text updates and graceful fallbacks when custom names are entered
- refresh the identity modal styling to accommodate the selector card, history pills, and text link for custom names

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d46eab147c8332a1bc250b9ba32544