### PR TITLE
Implement master identity setup flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,52 +212,96 @@
       <div id="identityModal" class="identity-modal" role="dialog" aria-modal="true" aria-labelledby="identityModalTitle" hidden>
         <div class="identity-dialog">
           <div class="identity-header">
-            <h3 id="identityModalTitle">Choose Your Identity</h3>
-            <p id="identityModalSubtitle">Secure your seat in this room</p>
+            <h3 id="identityModalTitle">Create Your Secure Identity</h3>
+            <p id="identityModalSubtitle">This identity works across all rooms on this device</p>
           </div>
 
-          <div id="identityModeCreate" class="identity-section">
-            <form id="identityCreateForm" novalidate>
-              <div class="identity-block">
-                <h4>Display Name</h4>
-                <p class="help-text">Pick a generated name or create your own</p>
-                <div id="identitySuggestions" class="name-suggestions"></div>
-                <div class="custom-name-option">
-                  <input type="text" id="identityNameInput" maxlength="30" placeholder="Or type your own…" autocomplete="off">
-                  <button type="button" id="identityRefreshBtn" class="refresh-btn">🎲 New suggestions</button>
+          <div id="identitySetupSection" class="identity-setup-flow">
+            <div class="setup-step">
+              <div class="step-icon">🔐</div>
+              <h4>Create Your Secure Identity</h4>
+              <p>This identity works across all rooms on this device.</p>
+            </div>
+
+            <form id="identitySetupForm" class="password-creation-form" novalidate>
+              <label class="form-label" for="identitySetupPassword">
+                Create your identity password
+                <span class="label-hint">You'll use this to unlock your identity</span>
+              </label>
+
+              <div class="password-input-group">
+                <input
+                  type="password"
+                  id="identitySetupPassword"
+                  placeholder="Choose a strong password"
+                  autocomplete="new-password"
+                  required
+                >
+                <button type="button" class="toggle-visibility" id="identityPasswordToggle" aria-label="Toggle password visibility">
+                  👁️
+                </button>
+              </div>
+
+              <div class="password-strength-meter">
+                <div class="strength-bar" id="identityStrengthBar" data-strength="0">
+                  <div class="strength-fill" id="identityStrengthFill"></div>
+                </div>
+                <span class="strength-text">Password strength: <span id="identityStrengthLabel">-</span></span>
+              </div>
+
+              <div class="password-requirements" id="identityRequirements">
+                <div class="requirement" data-requirement="length">
+                  <span class="check">○</span> At least 12 characters
+                </div>
+                <div class="requirement" data-requirement="mix">
+                  <span class="check">○</span> Mix of letters and numbers
+                </div>
+                <div class="requirement" data-requirement="special">
+                  <span class="check">○</span> At least one special character
                 </div>
               </div>
 
-              <div class="identity-block">
-                <h4>Password</h4>
-                <p class="help-text">Create a password to rejoin this room later</p>
-                <div class="password-input-group">
-                  <input type="password" id="identityPasswordInput" placeholder="Create room password" autocomplete="new-password" required>
-                  <div class="password-strength">
-                    <div id="identityStrengthBar" class="strength-bar" data-strength="0"></div>
-                    <span id="identityStrengthText" class="strength-text">Choose a strong password</span>
-                  </div>
-                </div>
-              </div>
+              <label class="form-label" for="identitySetupConfirm">Confirm password</label>
+              <input
+                type="password"
+                id="identitySetupConfirm"
+                placeholder="Confirm password"
+                autocomplete="new-password"
+                required
+              >
 
-              <div class="identity-actions">
-                <button type="submit" class="btn btn-primary" id="identitySubmitBtn">Join Secure Room</button>
-              </div>
+              <button type="submit" class="btn btn-primary" id="identityCreateBtn" disabled>
+                Create Secure Identity
+              </button>
             </form>
+
+            <div class="recovery-setup">
+              <p class="info-text">
+                💡 After setup, you'll get a recovery phrase to restore your identity on other devices
+              </p>
+            </div>
           </div>
 
-          <div id="identityModeReturning" class="identity-section" hidden>
-            <form id="identityReturningForm" novalidate>
-              <div class="identity-block">
-                <h4>Welcome Back</h4>
-                <p class="help-text">Enter your password to rejoin as <strong id="identityHint">You</strong></p>
-                <input type="password" id="identityReturningPassword" placeholder="Enter your room password" autocomplete="current-password" required>
-              </div>
-              <div class="identity-actions">
-                <button type="submit" class="btn btn-primary">Rejoin Room</button>
-                <button type="button" class="btn btn-secondary" id="identityUseNew">Join as someone new</button>
-              </div>
+          <div id="identityUnlockSection" class="unlock-identity" hidden>
+            <div class="identity-card">
+              <div class="avatar" id="identityUnlockAvatar" aria-hidden="true">🙂</div>
+              <h3 id="identityUnlockName">You</h3>
+              <span class="identity-id" id="identityUnlockCreated"></span>
+            </div>
+
+            <form id="identityUnlockForm" class="unlock-form" novalidate>
+              <label for="identityUnlockPassword">Enter your identity password</label>
+              <input
+                type="password"
+                id="identityUnlockPassword"
+                placeholder="Your identity password"
+                autocomplete="current-password"
+                required
+              >
+              <button type="submit" class="btn btn-primary">Unlock &amp; Join Room</button>
             </form>
+
+            <button type="button" class="link-button" id="identityForgotBtn">Forgot password?</button>
           </div>
 
           <div id="identityError" class="identity-error" role="alert" aria-live="assertive" hidden></div>

--- a/lib/identity.js
+++ b/lib/identity.js
@@ -69,104 +69,113 @@ class SecureNameGenerator {
   }
 }
 
-class SecureRoomStorage {
-  constructor(namespace = 'secure-room-identity') {
+class SecureIdentityStorage {
+  constructor(namespace = 'secure-master-identity') {
     this.namespace = namespace;
   }
 
-  async saveRoomIdentity(roomId, payload) {
-    if (!roomId || !payload) {
+  async saveIdentity(payload) {
+    if (!payload) {
       return;
     }
     try {
-      localStorage.setItem(this.key(roomId), JSON.stringify(payload));
+      localStorage.setItem(this.namespace, JSON.stringify(payload));
     } catch (error) {
-      console.warn('Unable to persist room identity.', error);
+      console.warn('Unable to persist identity.', error);
     }
   }
 
-  async getRoomIdentity(roomId) {
-    if (!roomId) {
-      return null;
-    }
+  async getIdentity() {
     try {
-      const stored = localStorage.getItem(this.key(roomId));
-      if (!stored) {
-        return null;
-      }
-      return JSON.parse(stored);
+      const stored = localStorage.getItem(this.namespace);
+      return stored ? JSON.parse(stored) : null;
     } catch (error) {
-      console.warn('Unable to read room identity.', error);
+      console.warn('Unable to read stored identity.', error);
       return null;
     }
   }
 
-  async clearRoomIdentity(roomId) {
+  async clearIdentity() {
     try {
-      localStorage.removeItem(this.key(roomId));
+      localStorage.removeItem(this.namespace);
     } catch (error) {
-      console.warn('Unable to clear room identity.', error);
+      console.warn('Unable to clear stored identity.', error);
     }
-  }
-
-  key(roomId) {
-    return `${this.namespace}:${roomId}`;
   }
 }
 
-class RoomIdentity {
-  constructor(roomId) {
-    if (!roomId) {
-      throw new Error('Room ID required to manage identity');
+class MasterIdentity {
+  constructor() {
+    if (typeof window === 'undefined') {
+      throw new Error('Window unavailable');
     }
-
-    this.roomId = roomId;
-    this.storage = new SecureRoomStorage();
+    this.storage = new SecureIdentityStorage();
+    this.nameGenerator = typeof SecureNameGenerator === 'function' ? new SecureNameGenerator() : null;
+    this.recoveryWords = this.buildRecoveryWordList();
   }
 
-  async createIdentity(displayName, password) {
-    if (!displayName || typeof displayName !== 'string') {
-      throw new Error('Display name required');
-    }
-    if (!password || password.length < 4) {
-      throw new Error('Password required');
+  async hasIdentity() {
+    const stored = await this.storage.getIdentity();
+    return Boolean(stored && stored.encrypted && stored.salt);
+  }
+
+  async getStoredProfile() {
+    const stored = await this.storage.getIdentity();
+    return stored?.profile || null;
+  }
+
+  async createIdentity(options = {}) {
+    const { password, displayName } = typeof options === 'object' ? options : { password: options };
+
+    if (!password || password.length < 12) {
+      throw new Error('Password must be at least 12 characters.');
     }
     if (!window?.crypto?.subtle) {
       throw new Error('WebCrypto unavailable for identity creation');
     }
 
+    const identityName = typeof displayName === 'string' && displayName.trim()
+      ? displayName.trim()
+      : this.generateDisplayName();
+
     const salt = crypto.getRandomValues(new Uint8Array(32));
     const keyMaterial = await this.getKeyMaterial(password);
-    const roomKey = await this.deriveKey(keyMaterial, salt, ['encrypt', 'decrypt']);
+    const identityKey = await this.deriveKey(keyMaterial, salt, ['encrypt']);
 
     const identity = {
       id: typeof crypto.randomUUID === 'function'
         ? crypto.randomUUID()
         : `id-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-      displayName,
-      avatar: this.generateAvatar(displayName),
+      displayName: identityName,
+      avatar: this.generateAvatar(identityName),
       created: Date.now(),
+      lastSeen: Date.now(),
       publicKey: await this.generatePublicKey(),
-      lastSeen: Date.now()
+      recoveryPhrase: this.generateRecoveryPhrase()
     };
 
-    const encryptedIdentity = await this.encrypt(identity, roomKey);
-    await this.storage.saveRoomIdentity(this.roomId, {
+    const encryptedIdentity = await this.encrypt(identity, identityKey);
+    await this.storage.saveIdentity({
       encrypted: encryptedIdentity,
       salt: this.toBase64(salt),
-      hint: `${displayName.slice(0, 3)}***`
+      profile: {
+        displayName: identity.displayName,
+        avatar: identity.avatar,
+        created: identity.created,
+        lastUnlocked: identity.lastSeen
+      }
     });
 
-    return identity;
+    return { identity, recoveryPhrase: identity.recoveryPhrase };
   }
 
-  async verifyReturningMember(password) {
+  async unlockIdentity(password) {
     if (!window?.crypto?.subtle) {
       throw new Error('WebCrypto unavailable for identity verification');
     }
 
-    const stored = await this.storage.getRoomIdentity(this.roomId);
-    if (!stored) {
+    const stored = await this.storage.getIdentity();
+    if (!stored?.encrypted || !stored?.salt) {
       return null;
     }
 
@@ -176,11 +185,26 @@ class RoomIdentity {
 
     const keyMaterial = await this.getKeyMaterial(password);
     const salt = this.fromBase64(stored.salt);
-    const roomKey = await this.deriveKey(keyMaterial, salt, ['decrypt']);
-
-    const identity = await this.decrypt(stored.encrypted, roomKey);
+    const identityKey = await this.deriveKey(keyMaterial, salt, ['decrypt']);
+    const identity = await this.decrypt(stored.encrypted, identityKey);
     identity.lastSeen = Date.now();
+
+    await this.storage.saveIdentity({
+      encrypted: stored.encrypted,
+      salt: stored.salt,
+      profile: {
+        displayName: identity.displayName,
+        avatar: identity.avatar,
+        created: identity.created,
+        lastUnlocked: identity.lastSeen
+      }
+    });
+
     return identity;
+  }
+
+  async clearIdentity() {
+    await this.storage.clearIdentity();
   }
 
   async getKeyMaterial(password) {
@@ -195,7 +219,7 @@ class RoomIdentity {
   }
 
   async deriveKey(keyMaterial, salt, usages) {
-    const key = await crypto.subtle.deriveKey(
+    return crypto.subtle.deriveKey(
       {
         name: 'PBKDF2',
         salt,
@@ -207,7 +231,6 @@ class RoomIdentity {
       false,
       usages
     );
-    return key;
   }
 
   async encrypt(data, key) {
@@ -249,10 +272,17 @@ class RoomIdentity {
     }
   }
 
+  generateDisplayName() {
+    if (this.nameGenerator && typeof this.nameGenerator.generate === 'function') {
+      return this.nameGenerator.generate({ includeNumber: true });
+    }
+    return `Secure-Member-${Math.floor(Math.random() * 900 + 100)}`;
+  }
+
   generateAvatar(name) {
     const emojis = ['🦊', '🦁', '🐺', '🦅', '🐉', '🦉', '🐯', '🦜', '🦋', '🐠'];
     const colors = ['#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7', '#DDA0DD'];
-    const hash = this.hashString(name);
+    const hash = this.hashString(name || 'member');
     const emoji = emojis[hash % emojis.length];
     const color = colors[Math.floor(hash / emojis.length) % colors.length];
     return { emoji, color };
@@ -288,6 +318,37 @@ class RoomIdentity {
       bytes[i] = binary.charCodeAt(i);
     }
     return bytes;
+  }
+
+  buildRecoveryWordList() {
+    if (this.nameGenerator) {
+      const base = [...(this.nameGenerator.adjectives || []), ...(this.nameGenerator.nouns || [])];
+      const extras = ['Signal', 'Cipher', 'Beacon', 'Vector', 'Nova', 'Atlas', 'Pulse', 'Quantum'];
+      return Array.from(new Set([...base, ...extras])).map((word) => word.toLowerCase());
+    }
+    return ['secure', 'signal', 'cipher', 'vector', 'quantum', 'beacon', 'atlas', 'nova', 'pulse', 'ember'];
+  }
+
+  generateRecoveryPhrase(length = 12) {
+    const words = this.recoveryWords && this.recoveryWords.length > 0
+      ? this.recoveryWords
+      : this.buildRecoveryWordList();
+    const phrase = [];
+    for (let i = 0; i < length; i++) {
+      const index = this.getRandomIndex(words.length);
+      phrase.push(words[index] || 'signal');
+    }
+    return phrase.join(' ');
+  }
+
+  getRandomIndex(max) {
+    if (max <= 0) {
+      return 0;
+    }
+    if (window?.crypto?.getRandomValues) {
+      return crypto.getRandomValues(new Uint32Array(1))[0] % max;
+    }
+    return Math.floor(Math.random() * max);
   }
 }
 
@@ -476,5 +537,6 @@ class RoomMembers {
 }
 
 window.SecureNameGenerator = SecureNameGenerator;
-window.RoomIdentity = RoomIdentity;
+window.MasterIdentity = MasterIdentity;
+window.RoomIdentity = MasterIdentity;
 window.RoomMembers = RoomMembers;

--- a/styles.css
+++ b/styles.css
@@ -1266,165 +1266,112 @@
       font-size: 0.95rem;
     }
 
-    .identity-section {
+    .identity-setup-flow {
       display: flex;
       flex-direction: column;
       gap: 1.5rem;
     }
 
-    .identity-block {
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
+    .setup-step {
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      border-radius: 14px;
+      padding: 1.25rem 1.5rem;
+      text-align: center;
     }
 
-    .identity-block h4 {
-      margin: 0;
-      font-size: 1rem;
+    .setup-step h4 {
+      margin: 0.5rem 0 0.25rem;
+      font-size: 1.1rem;
     }
 
-    .identity-block .help-text {
+    .setup-step p {
       margin: 0;
       color: #9da3b0;
-      font-size: 0.9rem;
-    }
-
-    .name-suggestions {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-      gap: 0.75rem;
-    }
-
-    .name-option {
-      border: 1px solid rgba(255, 255, 255, 0.08);
-      background: rgba(255, 255, 255, 0.04);
-      border-radius: 12px;
-      padding: 0.75rem 1rem;
-      text-align: left;
-      color: #fff;
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-      cursor: pointer;
-      transition: border 0.2s ease, transform 0.2s ease;
-      width: 100%;
-      outline: none;
-    }
-
-    .name-option:hover,
-    .name-option.selected {
-      border-color: var(--accent);
-      transform: translateY(-1px);
-    }
-
-    .name-option:focus-visible {
-      outline: 2px solid var(--accent);
-      outline-offset: 2px;
-    }
-
-    .name-option .name-avatar {
-      width: 36px;
-      height: 36px;
-      border-radius: 8px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 20px;
-      background: rgba(255, 255, 255, 0.08);
-    }
-
-    .custom-name-option {
-      display: flex;
-      gap: 0.75rem;
-      align-items: center;
-    }
-
-    .custom-name-option input {
-      flex: 1;
-      padding: 0.75rem 1rem;
-      border-radius: 10px;
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      background: rgba(255, 255, 255, 0.05);
-      color: #fff;
       font-size: 0.95rem;
     }
 
-    .custom-name-option input::placeholder {
-      color: rgba(255, 255, 255, 0.5);
+    .step-icon {
+      font-size: 2rem;
     }
 
-    .refresh-btn {
-      background: rgba(255, 255, 255, 0.08);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      border-radius: 8px;
-      padding: 0.75rem 1rem;
-      color: #fff;
-      cursor: pointer;
-      font-size: 0.9rem;
-      transition: background 0.2s ease;
+    .password-creation-form {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
     }
 
-    .refresh-btn:hover {
-      background: rgba(255, 255, 255, 0.12);
+    .form-label {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+      font-weight: 600;
+      font-size: 0.95rem;
+    }
+
+    .label-hint {
+      font-weight: 400;
+      color: #9da3b0;
+      font-size: 0.85rem;
     }
 
     .password-input-group {
+      position: relative;
       display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
+      align-items: center;
     }
 
     .password-input-group input {
+      width: 100%;
       padding: 0.9rem 1rem;
-      border-radius: 10px;
+      border-radius: 12px;
       border: 1px solid rgba(255, 255, 255, 0.1);
       background: rgba(255, 255, 255, 0.05);
       color: #fff;
+      font-size: 1rem;
     }
 
-    .password-strength {
+    .password-input-group input::placeholder {
+      color: rgba(255, 255, 255, 0.45);
+    }
+
+    .toggle-visibility {
+      position: absolute;
+      right: 0.75rem;
+      top: 50%;
+      transform: translateY(-50%);
+      background: none;
+      border: none;
+      color: #9da3b0;
+      cursor: pointer;
+      font-size: 1.1rem;
+      padding: 0.25rem;
+    }
+
+    .toggle-visibility:focus-visible {
+      outline: 2px solid var(--accent);
+      border-radius: 6px;
+    }
+
+    .password-strength-meter {
       display: flex;
       align-items: center;
       gap: 0.75rem;
     }
 
     .strength-bar {
-      height: 6px;
       flex: 1;
+      height: 6px;
       background: rgba(255, 255, 255, 0.1);
       border-radius: 4px;
-      position: relative;
       overflow: hidden;
     }
 
-    .strength-bar::after {
-      content: '';
-      position: absolute;
-      inset: 0;
-      transform-origin: left;
-      transform: scaleX(0.15);
+    .strength-fill {
+      width: 0;
+      height: 100%;
       background: #f87171;
-      transition: transform 0.3s ease, background 0.3s ease;
-    }
-
-    .strength-bar[data-strength="1"]::after {
-      transform: scaleX(0.3);
-      background: #f87171;
-    }
-
-    .strength-bar[data-strength="2"]::after {
-      transform: scaleX(0.6);
-      background: #fbbf24;
-    }
-
-    .strength-bar[data-strength="3"]::after {
-      transform: scaleX(0.85);
-      background: #34d399;
-    }
-
-    .strength-bar[data-strength="4"]::after {
-      transform: scaleX(1);
-      background: #22c55e;
+      transition: width 0.3s ease, background 0.3s ease;
     }
 
     .strength-text {
@@ -1432,10 +1379,113 @@
       font-size: 0.85rem;
     }
 
-    .identity-actions {
+    .password-requirements {
+      display: grid;
+      gap: 0.5rem;
+      margin: 0.25rem 0 0.5rem;
+    }
+
+    .requirement {
       display: flex;
-      gap: 0.75rem;
       align-items: center;
+      gap: 0.5rem;
+      font-size: 0.9rem;
+      color: #9da3b0;
+      transition: color 0.2s ease;
+    }
+
+    .requirement .check {
+      font-size: 0.8rem;
+    }
+
+    .requirement[data-met="true"] {
+      color: #34d399;
+    }
+
+    .requirement[data-met="true"] .check {
+      color: #34d399;
+    }
+
+    .recovery-setup {
+      background: rgba(52, 211, 153, 0.08);
+      border: 1px solid rgba(52, 211, 153, 0.3);
+      border-radius: 12px;
+      padding: 1rem;
+      color: #bbf7d0;
+      font-size: 0.9rem;
+    }
+
+    .unlock-identity {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    .identity-card {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      gap: 0.5rem;
+      border-radius: 16px;
+      padding: 1.5rem;
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    .identity-card .avatar {
+      width: 72px;
+      height: 72px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 2rem;
+      margin-bottom: 0.5rem;
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    .identity-card h3 {
+      margin: 0;
+      font-size: 1.2rem;
+    }
+
+    .identity-id {
+      color: #9da3b0;
+      font-size: 0.85rem;
+    }
+
+    .unlock-form {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .unlock-form label {
+      font-weight: 600;
+      font-size: 0.95rem;
+    }
+
+    .unlock-form input {
+      padding: 0.9rem 1rem;
+      border-radius: 12px;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.05);
+      color: #fff;
+    }
+
+    .link-button {
+      background: none;
+      border: none;
+      color: var(--accent);
+      padding: 0;
+      text-align: left;
+      font-size: 0.95rem;
+      cursor: pointer;
+    }
+
+    .link-button:hover {
+      text-decoration: underline;
     }
 
     .identity-error {


### PR DESCRIPTION
## Summary
- replace the room-specific identity modal with a device-wide identity setup and unlock flow
- add a MasterIdentity manager that encrypts a reusable profile and recovery phrase in localStorage
- refresh identity modal styling for the new setup, strength meter, and unlock card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d46ebc6ac88332ab90820dc937e10c