### PR TITLE
Add Slack-like members sidebar and supporting styling updates

### DIFF
--- a/lib/identity.js
+++ b/lib/identity.js
@@ -291,21 +291,38 @@ class RoomIdentity {
   }
 }
 
-class RoomMembers {
+class RoomMembersPanel {
   constructor(rootElement) {
     this.rootElement = rootElement || null;
     this.members = new Map();
-    this.presenceTimeout = 30000;
+    this.pendingInvites = [];
+    this.activeTab = 'members';
+    this.viewerIsHost = false;
     this.refreshInterval = null;
+    this.boundHandleClick = (event) => this.handleInteraction(event.target, event);
+    this.boundHandleKeyDown = (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        this.handleInteraction(event.target, event);
+      }
+    };
     this.ensureRefresh();
+    this.attachRootHandlers();
     this.render();
+  }
+
+  attachRootHandlers() {
+    if (this.rootElement && !this.rootElement.__roomMembersBound) {
+      this.rootElement.addEventListener('click', this.boundHandleClick);
+      this.rootElement.addEventListener('keydown', this.boundHandleKeyDown);
+      this.rootElement.__roomMembersBound = true;
+    }
   }
 
   ensureRefresh() {
     if (this.refreshInterval) {
       return;
     }
-    this.refreshInterval = setInterval(() => this.render(), 10000);
+    this.refreshInterval = setInterval(() => this.render(), 5000);
   }
 
   dispose() {
@@ -313,7 +330,24 @@ class RoomMembers {
       clearInterval(this.refreshInterval);
       this.refreshInterval = null;
     }
+    if (this.rootElement?.__roomMembersBound) {
+      this.rootElement.removeEventListener('click', this.boundHandleClick);
+      this.rootElement.removeEventListener('keydown', this.boundHandleKeyDown);
+      delete this.rootElement.__roomMembersBound;
+    }
     this.members.clear();
+    this.pendingInvites = [];
+    this.render();
+  }
+
+  setViewerRole(isHost) {
+    this.viewerIsHost = Boolean(isHost);
+    this.render();
+  }
+
+  reset() {
+    this.members.clear();
+    this.pendingInvites = [];
     this.render();
   }
 
@@ -329,10 +363,12 @@ class RoomMembers {
       displayName: identity.displayName || existing.displayName || 'Member',
       avatar: identity.avatar || existing.avatar || { emoji: '🙂', color: '#4A9FD5' },
       publicKey: identity.publicKey || existing.publicKey || null,
-      isHost: options.isHost ?? existing.isHost ?? false,
-      verified: options.verified ?? existing.verified ?? false,
-      online: options.online ?? existing.online ?? false,
-      lastSeen: options.lastSeen ?? existing.lastSeen ?? now
+      isHost: Boolean(options.isHost ?? existing.isHost ?? identity.isHost),
+      verified: Boolean(options.verified ?? existing.verified ?? identity.verified),
+      online: Boolean(options.online ?? existing.online ?? false),
+      lastSeen: Number.isFinite(options.lastSeen) ? options.lastSeen : existing.lastSeen ?? now,
+      isTyping: Boolean(options.isTyping ?? existing.isTyping ?? false),
+      pingMs: Number.isFinite(options.pingMs) ? options.pingMs : existing.pingMs ?? null
     };
 
     if (member.online) {
@@ -343,37 +379,36 @@ class RoomMembers {
     this.render();
   }
 
-  markOffline(memberId) {
+  updateMember(memberId, updates = {}) {
     const member = this.members.get(memberId);
     if (!member) {
       return;
     }
-    member.online = false;
-    member.lastSeen = Date.now();
+    const now = Date.now();
+    if (updates.online) {
+      member.lastSeen = now;
+    }
+    Object.assign(member, updates);
+    if (updates.online) {
+      member.online = true;
+    }
+    if (typeof updates.online === 'boolean' && !updates.online) {
+      member.lastSeen = now;
+    }
     this.members.set(memberId, member);
     this.render();
+  }
+
+  markOffline(memberId) {
+    this.updateMember(memberId, { online: false });
   }
 
   markOnline(memberId) {
-    const member = this.members.get(memberId);
-    if (!member) {
-      return;
-    }
-    member.online = true;
-    member.lastSeen = Date.now();
-    this.members.set(memberId, member);
-    this.render();
+    this.updateMember(memberId, { online: true });
   }
 
   updatePresence(memberId) {
-    const member = this.members.get(memberId);
-    if (!member) {
-      return;
-    }
-    member.lastSeen = Date.now();
-    member.online = true;
-    this.members.set(memberId, member);
-    this.render();
+    this.updateMember(memberId, { online: true, lastSeen: Date.now() });
   }
 
   removeMember(memberId) {
@@ -382,30 +417,175 @@ class RoomMembers {
     }
   }
 
+  setActiveInvite(invite) {
+    if (!invite) {
+      this.pendingInvites = [];
+      this.render();
+      return;
+    }
+
+    const expiresAt = Number(invite.expiresAt || invite.expiry || invite.expires);
+    const inviteId = invite.id || invite.seatId || invite.token || `invite-${Date.now()}`;
+    const createdAt = Number(invite.createdAt || Date.now());
+
+    this.pendingInvites = [
+      {
+        id: inviteId,
+        expiresAt: Number.isFinite(expiresAt) ? expiresAt : null,
+        createdAt,
+        url: invite.url || '',
+        remainingTime: this.formatRemainingTime(expiresAt)
+      }
+    ];
+    this.render();
+  }
+
+  clearActiveInvites() {
+    if (this.pendingInvites.length === 0) {
+      return;
+    }
+    this.pendingInvites = [];
+    this.render();
+  }
+
+  handleInteraction(target, event) {
+    if (!this.rootElement?.contains(target)) {
+      return;
+    }
+
+    const tabButton = target.closest('[data-tab-target]');
+    if (tabButton) {
+      event?.preventDefault?.();
+      const target = tabButton.dataset.tabTarget;
+      if (target && target !== this.activeTab) {
+        this.activeTab = target;
+        this.render();
+        if (target === 'chat') {
+          const input = document?.getElementById?.('messageInput');
+          input?.focus?.();
+        }
+      }
+      return;
+    }
+
+    const actionBtn = target.closest('[data-room-action]');
+    if (actionBtn) {
+      event?.preventDefault?.();
+      const action = actionBtn.dataset.roomAction;
+      switch (action) {
+        case 'invite':
+          if (window.App?.refreshGuestInvite) {
+            window.App.refreshGuestInvite({ announce: true });
+          }
+          this.dispatchCustomEvent('room-members:invite');
+          break;
+        case 'settings':
+          this.dispatchCustomEvent('room-members:settings');
+          break;
+        case 'close':
+          if (window.App?.disconnect) {
+            window.App.disconnect();
+          }
+          this.dispatchCustomEvent('room-members:close-room');
+          break;
+        case 'leave':
+          if (window.App?.disconnect) {
+            window.App.disconnect();
+          }
+          this.dispatchCustomEvent('room-members:leave-room');
+          break;
+        case 'cancel-invite':
+          {
+            const inviteId = actionBtn.dataset.inviteId || null;
+            if (window.App?.cancelActiveInvite) {
+              window.App.cancelActiveInvite(inviteId);
+            } else {
+              this.clearActiveInvites();
+            }
+            this.dispatchCustomEvent('room-members:cancel-invite', { inviteId });
+          }
+          break;
+        default:
+          break;
+      }
+      return;
+    }
+
+    const memberItem = target.closest('.member-item[data-member-id]');
+    if (memberItem) {
+      const memberId = memberItem.dataset.memberId;
+      this.dispatchCustomEvent('room-members:member-selected', { memberId });
+    }
+  }
+
+  dispatchCustomEvent(name, detail = {}) {
+    if (!this.rootElement) {
+      return;
+    }
+    const event = new CustomEvent(name, { bubbles: true, detail });
+    this.rootElement.dispatchEvent(event);
+  }
+
   render() {
     if (!this.rootElement) {
       return;
     }
 
-    const members = Array.from(this.members.values()).sort((a, b) => {
+    const members = Array.from(this.members.values());
+    const sortedMembers = members.sort((a, b) => {
       if (a.isHost && !b.isHost) return -1;
       if (!a.isHost && b.isHost) return 1;
+      if (a.online && !b.online) return -1;
+      if (!a.online && b.online) return 1;
       return a.displayName.localeCompare(b.displayName);
     });
 
+    const onlineMembers = sortedMembers.filter((member) => member.online);
+    const offlineMembers = sortedMembers.filter((member) => !member.online);
+    const pendingInvites = this.pendingInvites.map((invite) => ({
+      ...invite,
+      remainingTime: this.formatRemainingTime(invite.expiresAt)
+    }));
+    const tabIds = {
+      chat: 'room-panel-tab-chat',
+      members: 'room-panel-tab-members',
+      info: 'room-panel-tab-info'
+    };
+    const tabButtonIds = {
+      chat: 'room-panel-btn-chat',
+      members: 'room-panel-btn-members',
+      info: 'room-panel-btn-info'
+    };
+
     const markup = `
       <div class="members-sidebar-inner">
-        <div class="members-header">
-          <span class="member-count">${members.length}</span>
-          <span>Room Members</span>
+        <div class="room-tabs" role="tablist">
+          <button class="tab ${this.activeTab === 'chat' ? 'active' : ''}" id="${tabButtonIds.chat}" data-tab-target="chat" role="tab" aria-selected="${this.activeTab === 'chat'}" aria-controls="${tabIds.chat}">
+            <span>💬</span> Chat
+          </button>
+          <button class="tab ${this.activeTab === 'members' ? 'active' : ''}" id="${tabButtonIds.members}" data-tab-target="members" role="tab" aria-selected="${this.activeTab === 'members'}" aria-controls="${tabIds.members}">
+            <span>👥</span> Members (${onlineMembers.length + offlineMembers.length})
+          </button>
+          <button class="tab ${this.activeTab === 'info' ? 'active' : ''}" id="${tabButtonIds.info}" data-tab-target="info" role="tab" aria-selected="${this.activeTab === 'info'}" aria-controls="${tabIds.info}">
+            <span>ℹ️</span> Room Info
+          </button>
         </div>
-        <div class="members-list">
-          ${members
-            .map((member) => this.renderMember(member))
-            .join('')}
+
+        <div class="tab-content ${this.activeTab === 'chat' ? 'active' : ''}" id="${tabIds.chat}" data-tab="chat" role="tabpanel" aria-labelledby="${tabButtonIds.chat}">
+          <div class="chat-tab-placeholder">
+            <p>Use the main chat area to send secure messages. Switch to the Members tab to see who else is here.</p>
+          </div>
         </div>
-        <div class="members-footer">
-          <div class="encryption-status">🔐 All messages end-to-end encrypted</div>
+
+        <div class="tab-content members-panel ${this.activeTab === 'members' ? 'active' : ''}" id="${tabIds.members}" data-tab="members" role="tabpanel" aria-labelledby="${tabButtonIds.members}">
+          ${this.renderMembersSection('Online', onlineMembers, true)}
+          ${offlineMembers.length > 0 ? this.renderMembersSection('Offline', offlineMembers, false) : ''}
+          ${pendingInvites.length > 0 ? this.renderInvitesSection(pendingInvites) : ''}
+          ${this.renderActions()}
+        </div>
+
+        <div class="tab-content room-info-panel ${this.activeTab === 'info' ? 'active' : ''}" id="${tabIds.info}" data-tab="info" role="tabpanel" aria-labelledby="${tabButtonIds.info}">
+          ${this.renderRoomInfo(sortedMembers)}
         </div>
       </div>
     `;
@@ -413,53 +593,184 @@ class RoomMembers {
     this.rootElement.innerHTML = markup;
   }
 
-  renderMember(member) {
-    const statusClass = member.online ? 'online' : 'offline';
-    const statusText = member.online
-      ? 'Active'
-      : `Last seen ${this.formatTime(member.lastSeen)}`;
-    const badge = [member.isHost ? '👑' : '', member.verified ? '✓' : '']
-      .filter(Boolean)
-      .join(' ');
-
-    const avatarColor = member.avatar?.color || '#4A9FD5';
-    const avatarEmoji = member.avatar?.emoji || '🙂';
-
+  renderMembersSection(title, members, isOnline) {
+    const count = members.length;
     return `
-      <div class="member-item" data-id="${member.id}">
-        <div class="member-avatar" style="--avatar-color: ${avatarColor}; background: ${avatarColor};">
-          ${avatarEmoji}
-        </div>
-        <div class="member-info">
-          <div class="member-name">${this.escapeHtml(member.displayName)}</div>
-          <div class="member-status">
-            <span class="status-dot ${statusClass}"></span>
-            ${statusText}
-          </div>
-        </div>
-        <div class="member-badge">${badge}</div>
+      <div class="member-section">
+        <h4 class="section-header">${title} — ${count}</h4>
+        ${count === 0 ? '<div class="empty-state">No members yet.</div>' : members.map((member) => this.renderMember(member, isOnline)).join('')}
       </div>
     `;
   }
 
-  formatTime(timestamp) {
+  renderInvitesSection(invites) {
+    return `
+      <div class="member-section">
+        <h4 class="section-header">Pending Invites — ${invites.length}</h4>
+        ${invites
+          .map((invite) => `
+            <div class="pending-invite">
+              <div class="invite-icon">🎟️</div>
+              <div class="invite-info">
+                <span>Invite link active</span>
+                <span class="expire-time">${invite.remainingTime}</span>
+              </div>
+              <button class="cancel-btn" data-room-action="cancel-invite" data-invite-id="${this.escapeHtml(invite.id)}">
+                Cancel
+              </button>
+            </div>
+          `)
+          .join('')}
+      </div>
+    `;
+  }
+
+  renderActions() {
+    return `
+      <div class="room-actions">
+        ${this.viewerIsHost
+          ? `
+            <button class="action-btn" data-room-action="invite">
+              <span>➕</span> Invite Someone
+            </button>
+            <button class="action-btn" data-room-action="settings">
+              <span>⚙️</span> Room Settings
+            </button>
+            <button class="action-btn danger" data-room-action="close">
+              <span>🚪</span> Close Room
+            </button>
+          `
+          : `
+            <button class="action-btn" data-room-action="leave">
+              <span>👋</span> Leave Room
+            </button>
+          `}
+      </div>
+    `;
+  }
+
+  renderRoomInfo(members) {
+    const host = members.find((member) => member.isHost);
+    const totalMembers = members.length;
+    const onlineMembers = members.filter((member) => member.online).length;
+    const hostName = host ? this.escapeHtml(host.displayName) : 'Unknown';
+    const roleText = this.viewerIsHost ? 'You are hosting this room.' : 'You are a guest in this room.';
+
+    return `
+      <div class="room-info">
+        <div class="info-row">
+          <span class="info-label">Security</span>
+          <span class="info-value">🔐 End-to-end encrypted</span>
+        </div>
+        <div class="info-row">
+          <span class="info-label">Host</span>
+          <span class="info-value">${hostName}</span>
+        </div>
+        <div class="info-row">
+          <span class="info-label">Members</span>
+          <span class="info-value">${onlineMembers} online · ${totalMembers} total</span>
+        </div>
+        <div class="info-row">
+          <span class="info-label">Your role</span>
+          <span class="info-value">${roleText}</span>
+        </div>
+      </div>
+    `;
+  }
+
+  renderMember(member, isOnline) {
+    const avatarColor = member.avatar?.color || '#4A9FD5';
+    const avatarEmoji = member.avatar?.emoji || '🙂';
+    const name = this.escapeHtml(member.displayName);
+    const status = isOnline
+      ? member.isTyping
+        ? 'typing…'
+        : 'Active now'
+      : `Last seen ${this.formatLastSeen(member.lastSeen)}`;
+    const bars = this.getConnectionBars(member.pingMs);
+    const pingLabel = Number.isFinite(member.pingMs) ? `${member.pingMs}ms latency` : 'Latency unknown';
+
+    return `
+      <div class="member-item" data-member-id="${this.escapeHtml(member.id)}" role="button" tabindex="0">
+        <div class="member-presence">
+          <div class="member-avatar" style="background: ${avatarColor};">${avatarEmoji}</div>
+          <span class="presence-indicator ${isOnline ? 'online' : 'offline'}" aria-hidden="true"></span>
+        </div>
+        <div class="member-info">
+          <div class="member-name">
+            ${name}
+            ${member.isHost ? '<span class="host-crown" title="Host">👑</span>' : ''}
+          </div>
+          <div class="member-status">
+            ${isOnline ? `<span class="typing-indicator">${status}</span>` : `<span class="last-seen">${status}</span>`}
+          </div>
+        </div>
+        <div class="member-meta">
+          <span class="connection-quality" title="${pingLabel}">${bars}</span>
+        </div>
+      </div>
+    `;
+  }
+
+  formatLastSeen(timestamp) {
     if (!timestamp) {
       return 'recently';
     }
     const diff = Date.now() - timestamp;
-    if (diff < 60000) {
+    if (diff < 15000) {
       return 'just now';
+    }
+    if (diff < 60000) {
+      return `${Math.max(1, Math.floor(diff / 1000))}s ago`;
     }
     if (diff < 3600000) {
       const minutes = Math.max(1, Math.floor(diff / 60000));
-      return `${minutes} min ago`;
+      return `${minutes}m ago`;
     }
-    const hours = Math.max(1, Math.floor(diff / 3600000));
-    if (hours < 24) {
-      return `${hours} hr ago`;
+    if (diff < 86400000) {
+      const hours = Math.max(1, Math.floor(diff / 3600000));
+      return `${hours}h ago`;
     }
-    const days = Math.floor(diff / 86400000);
-    return `${days} day${days === 1 ? '' : 's'} ago`;
+    const days = Math.max(1, Math.floor(diff / 86400000));
+    return `${days}d ago`;
+  }
+
+  formatRemainingTime(expiresAt) {
+    if (!Number.isFinite(expiresAt)) {
+      return 'Expires soon';
+    }
+    const diff = expiresAt - Date.now();
+    if (diff <= 0) {
+      return 'Expired';
+    }
+    const seconds = Math.floor(diff / 1000);
+    const minutes = Math.floor(seconds / 60);
+    if (minutes >= 60) {
+      const hours = Math.floor(minutes / 60);
+      const mins = minutes % 60;
+      return `Expires in ${hours}h ${mins}m`;
+    }
+    if (minutes > 0) {
+      const secs = seconds % 60;
+      return `Expires in ${minutes}m ${secs.toString().padStart(2, '0')}s`;
+    }
+    return `Expires in ${seconds}s`;
+  }
+
+  getConnectionBars(pingMs) {
+    if (!Number.isFinite(pingMs)) {
+      return '📶';
+    }
+    if (pingMs <= 120) {
+      return '▂▃▄▅▇';
+    }
+    if (pingMs <= 240) {
+      return '▂▃▄▅';
+    }
+    if (pingMs <= 480) {
+      return '▂▃▄';
+    }
+    return '▂▃';
   }
 
   escapeHtml(value) {
@@ -477,4 +788,4 @@ class RoomMembers {
 
 window.SecureNameGenerator = SecureNameGenerator;
 window.RoomIdentity = RoomIdentity;
-window.RoomMembers = RoomMembers;
+window.RoomMembers = RoomMembersPanel;

--- a/styles.css
+++ b/styles.css
@@ -1112,116 +1112,319 @@
     }
 
     .members-sidebar {
-      background: #2c2d30;
-      border-left: 1px solid #1a1b1d;
+      background: #f8fafc;
+      border-left: 1px solid #e2e8f0;
       display: flex;
       flex-direction: column;
       min-height: 0;
+      color: #0f172a;
     }
 
     .members-sidebar-inner {
       display: flex;
       flex-direction: column;
       height: 100%;
+      background: #ffffff;
     }
 
-    .members-header {
-      padding: 16px;
-      border-bottom: 1px solid #1a1b1d;
+    .room-tabs {
+      display: flex;
+      gap: 1px;
+      background: #e2e8f0;
+      padding: 1px;
+      border-radius: 12px 12px 0 0;
+      margin: 1.25rem 1.25rem 0;
+    }
+
+    .tab {
+      flex: 1;
+      padding: 0.75rem 1rem;
+      background: transparent;
+      border: none;
+      cursor: pointer;
       display: flex;
       align-items: center;
-      gap: 8px;
-      color: #fff;
-      font-weight: 600;
+      justify-content: center;
+      gap: 0.5rem;
+      color: #64748b;
+      font-weight: 500;
+      transition: all 0.2s ease;
+      border-radius: 10px;
     }
 
-    .member-count {
-      background: #4a9fd5;
-      padding: 2px 8px;
-      border-radius: 12px;
-      font-size: 12px;
+    .tab:hover {
+      color: #0f172a;
+      background: rgba(255, 255, 255, 0.7);
     }
 
-    .members-list {
-      flex: 1;
+    .tab.active {
+      background: #ffffff;
+      color: #0f172a;
+      box-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
+    }
+
+    .tab-content {
+      display: none;
+      padding: 1.25rem;
+      height: 100%;
       overflow-y: auto;
-      padding: 8px 0;
+    }
+
+    .tab-content.active {
+      display: block;
+    }
+
+    .members-panel {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    .member-section {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .section-header {
+      margin: 0;
+      color: #334155;
+      font-size: 0.85rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
     }
 
     .member-item {
       display: flex;
       align-items: center;
-      padding: 8px 16px;
-      gap: 12px;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 0.75rem 1rem;
+      background: #f1f5f9;
+      border-radius: 12px;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
       cursor: pointer;
-      transition: background 0.2s ease;
     }
 
     .member-item:hover {
-      background: rgba(255, 255, 255, 0.05);
+      transform: translateY(-2px);
+      box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+    }
+
+    .member-presence {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      position: relative;
     }
 
     .member-avatar {
-      width: 36px;
-      height: 36px;
-      border-radius: 10px;
+      width: 44px;
+      height: 44px;
+      border-radius: 14px;
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 20px;
-      background: var(--avatar-color, #4a9fd5);
+      font-size: 1.5rem;
+      background: #e2e8f0;
+      position: relative;
+      overflow: hidden;
+      box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.05);
+    }
+
+    .presence-indicator {
+      position: absolute;
+      bottom: 4px;
+      right: 4px;
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      border: 2px solid #ffffff;
+      box-shadow: 0 2px 6px rgba(15, 23, 42, 0.1);
+    }
+
+    .presence-indicator.online {
+      background: #22c55e;
+      box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.15);
+    }
+
+    .presence-indicator.offline {
+      background: #94a3b8;
     }
 
     .member-info {
+      flex: 1;
       display: flex;
       flex-direction: column;
-      gap: 2px;
+      gap: 0.25rem;
+      min-width: 0;
     }
 
     .member-name {
-      color: #fff;
-      font-size: 14px;
-      font-weight: 500;
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-weight: 600;
+      color: #0f172a;
+      font-size: 0.95rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
-    .members-sidebar .status-dot {
-      width: 8px;
-      height: 8px;
-      border-radius: 50%;
-      margin-right: 0;
-    }
-
-    .members-sidebar .status-dot.online {
-      background: #44b700;
-      box-shadow: 0 0 0 2px rgba(68, 183, 0, 0.2);
-      border: none;
-    }
-
-    .members-sidebar .status-dot.offline {
-      background: transparent;
-      border: 2px solid #a0a0a2;
+    .host-crown {
+      font-size: 0.9rem;
     }
 
     .member-status {
+      font-size: 0.8rem;
+      color: #64748b;
+    }
+
+    .typing-indicator {
+      color: #22c55e;
+      font-weight: 600;
+    }
+
+    .last-seen {
+      color: #94a3b8;
+    }
+
+    .member-meta {
+      color: #475569;
+      font-size: 0.8rem;
+    }
+
+    .connection-quality {
+      font-family: 'Courier New', monospace;
+      letter-spacing: 1px;
+    }
+
+    .pending-invite {
       display: flex;
       align-items: center;
-      gap: 6px;
-      font-size: 12px;
-      color: #a0a0a2;
+      gap: 1rem;
+      background: #fff7ed;
+      border: 1px solid #fed7aa;
+      padding: 0.75rem 1rem;
+      border-radius: 12px;
     }
 
-    .member-badge {
-      margin-left: auto;
+    .invite-icon {
+      font-size: 1.5rem;
+    }
+
+    .invite-info {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      color: #b45309;
+      font-size: 0.85rem;
+    }
+
+    .expire-time {
+      font-weight: 600;
+    }
+
+    .cancel-btn {
+      border: none;
+      background: #f97316;
       color: #fff;
-      font-size: 14px;
+      padding: 0.5rem 0.9rem;
+      border-radius: 8px;
+      cursor: pointer;
+      font-weight: 600;
+      transition: background 0.2s ease;
     }
 
-    .members-footer {
-      padding: 16px;
-      border-top: 1px solid #1a1b1d;
-      color: #a0a0a2;
-      font-size: 12px;
+    .cancel-btn:hover {
+      background: #ea580c;
+    }
+
+    .room-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      margin-top: auto;
+    }
+
+    .action-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      padding: 0.75rem 1rem;
+      border-radius: 10px;
+      border: none;
+      background: #e2e8f0;
+      color: #1e293b;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .action-btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+    }
+
+    .action-btn.danger {
+      background: #fef2f2;
+      color: #dc2626;
+    }
+
+    .chat-tab-placeholder {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 200px;
+      color: #64748b;
       text-align: center;
+      background: #f8fafc;
+      border-radius: 16px;
+      border: 1px dashed #cbd5f5;
+      padding: 2rem;
+    }
+
+    .room-info-panel {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .room-info {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .info-row {
+      display: flex;
+      justify-content: space-between;
+      background: #f1f5f9;
+      padding: 0.75rem 1rem;
+      border-radius: 10px;
+      font-size: 0.9rem;
+    }
+
+    .info-label {
+      color: #475569;
+      font-weight: 600;
+    }
+
+    .info-value {
+      color: #1e293b;
+    }
+
+    .empty-state {
+      padding: 1rem;
+      border-radius: 12px;
+      background: #f8fafc;
+      color: #94a3b8;
+      text-align: center;
+      font-size: 0.85rem;
     }
 
     .identity-modal {
@@ -1446,6 +1649,115 @@
       border: 1px solid rgba(248, 113, 113, 0.4);
       color: #fecaca;
       font-size: 0.9rem;
+    }
+
+    .identity-setup-flow {
+      max-width: 400px;
+      margin: 0 auto;
+    }
+
+    .password-strength-meter {
+      margin: 1rem 0;
+      background: #f1f5f9;
+      height: 8px;
+      border-radius: 4px;
+      overflow: hidden;
+    }
+
+    .strength-fill {
+      height: 100%;
+      transition: all 0.3s;
+      background: linear-gradient(90deg, #ef4444 0%, #f59e0b 33%, #eab308 66%, #22c55e 100%);
+      width: var(--strength, 0%);
+    }
+
+    .requirement {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.25rem 0;
+      color: #64748b;
+      transition: color 0.2s ease;
+    }
+
+    .requirement[data-met="true"] {
+      color: #22c55e;
+    }
+
+    .requirement[data-met="true"] .check {
+      color: #22c55e;
+    }
+
+    .seats-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 1rem;
+      margin: 1.5rem 0;
+    }
+
+    .seat {
+      aspect-ratio: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      border: 2px dashed #cbd5e1;
+      border-radius: 12px;
+      padding: 1rem;
+      transition: all 0.3s ease;
+    }
+
+    .seat.occupied {
+      border-style: solid;
+      border-color: #3b82f6;
+      background: #eff6ff;
+    }
+
+    .seat.available:hover {
+      border-color: #94a3b8;
+      background: #f8fafc;
+      cursor: pointer;
+    }
+
+    .empty-seat {
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      background: #e2e8f0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.5rem;
+      color: #94a3b8;
+    }
+
+    .invite-redemption {
+      max-width: 400px;
+      margin: 0 auto;
+      padding: 2rem;
+      background: #ffffff;
+      border-radius: 16px;
+      box-shadow: 0 20px 60px rgba(15, 23, 42, 0.15);
+    }
+
+    .member-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 0.75rem;
+      background: #f1f5f9;
+      border-radius: 20px;
+      margin: 0.25rem;
+      color: #1e293b;
+    }
+
+    .host-badge {
+      background: linear-gradient(135deg, #fbbf24, #f59e0b);
+      color: #fff;
+      padding: 0.125rem 0.5rem;
+      border-radius: 10px;
+      font-size: 0.75rem;
+      font-weight: 600;
     }
 
     .schema-modal {


### PR DESCRIPTION
## Summary
- replace the simple member list with a tabbed RoomMembersPanel that shows online/offline presence, pending invites, and room actions
- wire the members panel into SecureChat invite lifecycle and role changes so host tools and invite cancellation stay in sync
- refresh the members sidebar styles and add utility styles for upcoming identity, seat, and invite flows

## Testing
- node tests/crypto.spec.js

------
https://chatgpt.com/codex/tasks/task_b_68d46ecf6c248332af14313bc8838669