### PR TITLE
Enhance chat attribution and presence

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,6 +30,7 @@ const DOM = {
   encryptedToggle: document.getElementById('encryptedToggle'),
   schemaToggle: document.getElementById('schemaToggle'),
   systemAnnouncements: document.getElementById('systemAnnouncements'),
+  typingIndicator: document.getElementById('typingIndicator'),
   memberSidebar: document.getElementById('memberSidebar'),
   identityModal: document.getElementById('identityModal'),
   identityCreateForm: document.getElementById('identityCreateForm'),
@@ -387,6 +388,15 @@ class MessageTimeline {
     this.messagesContainer = container;
   }
 
+  normalizeAvatar(avatar) {
+    if (!avatar || typeof avatar !== 'object') {
+      return { emoji: '🙂', color: '#4A9FD5' };
+    }
+    const emoji = typeof avatar.emoji === 'string' ? avatar.emoji : '🙂';
+    const color = typeof avatar.color === 'string' ? avatar.color : '#4A9FD5';
+    return { emoji, color };
+  }
+
   isNearBottom() {
     const container = this.messagesContainer;
     if (!container) {
@@ -412,6 +422,10 @@ class MessageTimeline {
       const messageText = typeof msg.text === 'string'
         ? msg.text
         : (typeof msg.content === 'string' ? msg.content : '');
+      const senderName = typeof msg.displayName === 'string'
+        ? msg.displayName
+        : (msg.type === 'me' ? 'You' : 'Guest');
+      const avatar = this.normalizeAvatar(msg.avatar);
       return {
         id: msg.id,
         text: messageText,
@@ -431,7 +445,16 @@ class MessageTimeline {
         originalPosition: Number.isFinite(msg.originalPosition) ? msg.originalPosition : null,
         isOutOfOrder: Boolean(msg.isOutOfOrder),
         sequence: Number.isFinite(msg.sequence) ? msg.sequence : null,
-        editedAt: Number.isFinite(msg.editedAt) ? msg.editedAt : null
+        editedAt: Number.isFinite(msg.editedAt) ? msg.editedAt : null,
+        userId: msg.userId || null,
+        displayName: senderName,
+        avatar,
+        sender: {
+          id: msg.userId || null,
+          displayName: senderName,
+          avatar
+        },
+        isLocal: msg.type === 'me'
       };
     });
 
@@ -588,6 +611,16 @@ class SecureChat {
         this.highestIncomingSequence = 0;
         this.totalReceivedMessages = 0;
         this.reorderNoticeTimers = new Map();
+        this.typingUsers = new Map();
+        this.typingTimeouts = new Map();
+        this.lastTypingState = false;
+        this.lastTypingSentAt = 0;
+        this.typingResetTimer = null;
+        this.typingIndicator = DOM.typingIndicator || null;
+        if (this.typingIndicator) {
+          this.typingIndicator.innerHTML = '';
+          this.typingIndicator.setAttribute('hidden', '');
+        }
 
         this.dom = DOM;
         this.applyVisualConfig();
@@ -617,6 +650,8 @@ class SecureChat {
           input.addEventListener('keypress', (e) => {
             if (e.key === 'Enter') this.sendMessage();
           });
+          input.addEventListener('input', () => this.handleTypingActivity());
+          input.addEventListener('blur', () => this.stopTypingActivity());
         }
 
         const sendBtn = DOM.sendBtn;
@@ -1171,6 +1206,15 @@ class SecureChat {
           verified: identity.verified,
           lastSeen: Date.now()
         });
+
+        if (identity.id && this.typingUsers?.has(identity.id)) {
+          const entry = this.typingUsers.get(identity.id);
+          if (entry) {
+            entry.displayName = identity.displayName;
+            entry.avatar = identity.avatar;
+            this.renderTypingIndicator(Array.from(this.typingUsers.values()));
+          }
+        }
       }
 
       normalizeAvatar(avatar) {
@@ -2252,11 +2296,17 @@ This invite can be used only once. Share the link privately.`;
           return true;
         }
 
+        if (message.type === 'typing_state') {
+          this.handleTypingControl(message);
+          return true;
+        }
+
         return false;
       }
 
       handleDisconnect() {
         this.stopHeartbeat();
+        this.clearTypingState();
         if (this.conn) {
           try {
             this.conn.close();
@@ -2517,11 +2567,14 @@ This invite can be used only once. Share the link privately.`;
         }
 
         input.value = '';
+        this.stopTypingActivity();
         const sentAtLocal = this.getMonotonicTime();
 
         const sequenceNumber = this.outgoingMessageNumber;
         const routePath = this.getDefaultRoutePath('me');
         const hopCount = Math.max(routePath.length - 1, 1);
+        const localDisplayName = this.localIdentity?.displayName || 'You';
+        const localAvatar = this.normalizeAvatar(this.localIdentity?.avatar || this.computeAvatarFromName(localDisplayName));
 
         const envelope = {
           kind: 'data',
@@ -2568,7 +2621,9 @@ This invite can be used only once. Share the link privately.`;
               vectorClock: this.buildVectorClock(sequenceNumber, this.localIdentity?.id || this.localUserId),
               sequence: sequenceNumber,
               originalPosition: null,
-              isOutOfOrder: false
+              isOutOfOrder: false,
+              displayName: localDisplayName,
+              avatar: localAvatar
             },
             this.localUserId,
             [`room:${this.roomId}`, `msg:${messageId}`]
@@ -2615,6 +2670,7 @@ This invite can be used only once. Share the link privately.`;
         if (this.systemAnnouncements) {
           this.systemAnnouncements.textContent = '';
         }
+        this.clearTypingState();
         this.renderChatMessages([]);
       }
 
@@ -2682,64 +2738,464 @@ This invite can be used only once. Share the link privately.`;
           this.messageDetailCache.set(entry.id, { ...entry });
         });
 
+        const fragment = document.createDocumentFragment();
+        let lastMessageEntry = null;
+
         combined.forEach((entry) => {
           let element = null;
 
           if (entry.kind === 'system') {
             element = this.createSystemMessageElement(entry);
           } else if (entry.kind === 'message') {
+            if (entry.sender?.id) {
+              this.clearTypingUser(entry.sender.id);
+            }
             if (this.showEncrypted) {
               element = entry.encrypted
                 ? this.createEncryptedMessageElement(entry)
                 : this.createEncryptedPlaceholderElement(entry);
             } else {
-              element = this.createPlainMessageElement(entry);
+              const needsBreak = !lastMessageEntry || this.shouldShowTimeBreak(lastMessageEntry, entry);
+              if (needsBreak) {
+                fragment.appendChild(this.createTimeBreakElement(entry.displayAt ?? entry.at ?? Date.now()));
+              }
+              element = this.createPlainMessageElement(entry, lastMessageEntry);
+              lastMessageEntry = entry;
             }
           }
 
           if (element) {
-            container.appendChild(element);
+            fragment.appendChild(element);
           }
         });
+
+        container.appendChild(fragment);
 
         if (shouldStick) {
           container.scrollTop = container.scrollHeight;
         }
       }
 
-      createPlainMessageElement(entry) {
+      createPlainMessageElement(entry, previousEntry = null) {
         const { text, type, displayAt } = entry;
-        const message = document.createElement('div');
-        message.className = `message ${type}`;
+        const isLocal = type === 'me';
+        const sender = entry.sender || { id: entry.userId, displayName: entry.displayName, avatar: entry.avatar };
+        const name = sender?.displayName || (isLocal ? 'You' : 'Guest');
+        const shownTime = Number.isFinite(displayAt) ? displayAt : Date.now();
+        const previousSameSender = previousEntry && previousEntry.sender?.id && sender?.id
+          ? previousEntry.sender.id === sender.id
+          : previousEntry?.type === type;
+        const isNewTimeBlock = previousEntry ? this.shouldShowTimeBreak(previousEntry, entry) : true;
+        const isConsecutive = Boolean(previousEntry) && previousSameSender && !isNewTimeBlock;
+        const showAvatarHeader = !isLocal && (!isConsecutive || isNewTimeBlock);
 
-        const content = document.createElement('div');
-        content.className = 'message-content';
+        const message = document.createElement('div');
+        message.className = `message ${isLocal ? 'local' : 'remote'}`;
+        if (sender?.id) {
+          message.dataset.sender = sender.id;
+        }
+        message.dataset.consecutive = isConsecutive ? 'true' : 'false';
+
+        const palette = this.getAvatarPalette(sender);
+        if (palette) {
+          message.style.setProperty('--avatar-color-1', palette.primary);
+          message.style.setProperty('--avatar-color-2', palette.secondary);
+        }
+
+        if (showAvatarHeader) {
+          const header = document.createElement('div');
+          header.className = 'sender-header';
+
+          const avatarEl = document.createElement('div');
+          avatarEl.className = 'sender-avatar';
+          avatarEl.textContent = sender?.avatar?.emoji || '🙂';
+          header.appendChild(avatarEl);
+
+          const nameSpan = document.createElement('span');
+          nameSpan.className = 'sender-name';
+          nameSpan.textContent = name;
+          header.appendChild(nameSpan);
+
+          const timeSpan = document.createElement('span');
+          timeSpan.className = 'sender-time';
+          timeSpan.textContent = this.formatTimestamp(shownTime);
+          header.appendChild(timeSpan);
+
+          message.appendChild(header);
+        }
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'message-content-wrapper';
+
+        if (!isLocal && isConsecutive) {
+          const tooltip = document.createElement('span');
+          tooltip.className = 'sender-tooltip';
+          tooltip.textContent = name;
+          wrapper.appendChild(tooltip);
+        }
+
+        const bubble = document.createElement('div');
+        bubble.className = 'message-bubble';
 
         const textEl = document.createElement('div');
         textEl.className = 'message-text';
         textEl.textContent = text;
+        bubble.appendChild(textEl);
 
         const meta = document.createElement('div');
-        meta.className = 'message-time message-meta';
+        meta.className = 'message-meta';
+
+        if (isLocal) {
+          const status = document.createElement('span');
+          status.className = 'delivery-status';
+          status.textContent = this.getDeliveryStatusIcon(entry.state);
+          status.setAttribute('aria-label', `Message ${entry.state || 'sent'}`);
+          meta.appendChild(status);
+        }
 
         const timestamp = document.createElement('span');
         timestamp.className = 'timestamp';
-        const shownTime = Number.isFinite(displayAt) ? displayAt : Date.now();
-        timestamp.textContent = this.formatTimestamp(shownTime);
-
-        const stateDots = document.createElement('span');
-        stateDots.className = 'state-dots';
-        stateDots.textContent = this.getMessageStateDots(entry.state);
-        stateDots.setAttribute('aria-label', `Message ${entry.state || 'settled'}`);
-
+        timestamp.textContent = this.formatCompactTime(shownTime);
         meta.appendChild(timestamp);
-        meta.appendChild(stateDots);
 
-        content.appendChild(textEl);
-        content.appendChild(meta);
-        message.appendChild(content);
+        bubble.appendChild(meta);
+        wrapper.appendChild(bubble);
+        message.appendChild(wrapper);
 
         return this.applyMessageMetadata(message, entry);
+      }
+
+      createTimeBreakElement(timestamp) {
+        const when = Number.isFinite(timestamp) ? timestamp : Date.now();
+        const wrapper = document.createElement('div');
+        wrapper.className = 'time-break';
+
+        const lineBefore = document.createElement('span');
+        lineBefore.className = 'time-break-line';
+
+        const text = document.createElement('span');
+        text.className = 'time-break-text';
+        text.textContent = this.formatTimeBreak(when);
+
+        const lineAfter = document.createElement('span');
+        lineAfter.className = 'time-break-line';
+
+        wrapper.appendChild(lineBefore);
+        wrapper.appendChild(text);
+        wrapper.appendChild(lineAfter);
+
+        return wrapper;
+      }
+
+      formatCompactTime(timestamp) {
+        const value = Number.isFinite(timestamp) ? timestamp : Date.now();
+        const now = Date.now();
+        const diff = now - value;
+
+        if (diff < 60000) {
+          return 'now';
+        }
+
+        if (diff < 3600000) {
+          const mins = Math.max(1, Math.floor(diff / 60000));
+          return `${mins}m`;
+        }
+
+        const messageDate = new Date(value);
+        const today = new Date();
+
+        if (messageDate.toDateString() === today.toDateString()) {
+          return messageDate.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+        }
+
+        const weekAgo = new Date();
+        weekAgo.setDate(weekAgo.getDate() - 7);
+        if (messageDate >= weekAgo) {
+          return messageDate.toLocaleDateString([], { weekday: 'short', hour: 'numeric', minute: '2-digit' });
+        }
+
+        return messageDate.toLocaleDateString([], { month: 'short', day: 'numeric' });
+      }
+
+      formatTimeBreak(timestamp) {
+        const value = Number.isFinite(timestamp) ? timestamp : Date.now();
+        const date = new Date(value);
+        const now = new Date();
+        const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+        const startOfYesterday = new Date(startOfToday);
+        startOfYesterday.setDate(startOfYesterday.getDate() - 1);
+
+        if (date >= startOfToday) {
+          return `Today, ${date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`;
+        }
+
+        if (date >= startOfYesterday) {
+          return `Yesterday, ${date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`;
+        }
+
+        return date.toLocaleDateString([], {
+          weekday: 'long',
+          month: 'long',
+          day: 'numeric',
+          hour: 'numeric',
+          minute: '2-digit'
+        });
+      }
+
+      shouldShowTimeBreak(previousEntry, nextEntry) {
+        if (!previousEntry) {
+          return true;
+        }
+        if (!nextEntry) {
+          return false;
+        }
+        const prevTime = Number.isFinite(previousEntry.displayAt)
+          ? previousEntry.displayAt
+          : Number.isFinite(previousEntry.at) ? previousEntry.at : 0;
+        const nextTime = Number.isFinite(nextEntry.displayAt)
+          ? nextEntry.displayAt
+          : Number.isFinite(nextEntry.at) ? nextEntry.at : 0;
+
+        if (!Number.isFinite(prevTime) || !Number.isFinite(nextTime)) {
+          return false;
+        }
+
+        const diff = Math.abs(nextTime - prevTime);
+        if (diff > 300000) {
+          return true;
+        }
+
+        const prevDate = new Date(prevTime);
+        const nextDate = new Date(nextTime);
+        return prevDate.toDateString() !== nextDate.toDateString();
+      }
+
+      getDeliveryStatusIcon(state) {
+        switch (state) {
+          case 'sending':
+            return '…';
+          case 'propagating':
+            return '⇆';
+          case 'settling':
+            return '⌛';
+          case 'failed':
+            return '⚠';
+          case 'settled':
+          default:
+            return '✓✓';
+        }
+      }
+
+      getAvatarPalette(source) {
+        const baseColor = source?.avatar?.color || source?.color || '#4A9FD5';
+        const sanitized = typeof baseColor === 'string' && /^#([0-9a-f]{6})$/i.test(baseColor)
+          ? baseColor
+          : '#4A9FD5';
+        return {
+          primary: this.adjustColor(sanitized, 1.15),
+          secondary: this.adjustColor(sanitized, 0.85)
+        };
+      }
+
+      adjustColor(hex, factor) {
+        if (typeof hex !== 'string') {
+          return '#4A9FD5';
+        }
+        const normalized = hex.replace('#', '');
+        if (!/^[0-9a-f]{6}$/i.test(normalized)) {
+          return '#4A9FD5';
+        }
+        const r = parseInt(normalized.slice(0, 2), 16);
+        const g = parseInt(normalized.slice(2, 4), 16);
+        const b = parseInt(normalized.slice(4, 6), 16);
+        const adjust = (channel) => Math.min(255, Math.max(0, Math.round(channel * factor)));
+        return `#${this.toHexComponent(adjust(r))}${this.toHexComponent(adjust(g))}${this.toHexComponent(adjust(b))}`;
+      }
+
+      toHexComponent(value) {
+        const clamped = Math.min(255, Math.max(0, Math.round(value)));
+        return clamped.toString(16).padStart(2, '0');
+      }
+
+      handleTypingActivity() {
+        const input = DOM.messageInput;
+        if (!input) {
+          return;
+        }
+        const isActive = Boolean(input.value && input.value.trim().length > 0);
+        this.setLocalTyping(isActive);
+      }
+
+      stopTypingActivity() {
+        this.setLocalTyping(false);
+      }
+
+      setLocalTyping(active) {
+        const normalized = Boolean(active);
+        const now = Date.now();
+
+        if (normalized) {
+          if (this.typingResetTimer) {
+            clearTimeout(this.typingResetTimer);
+          }
+          this.typingResetTimer = setTimeout(() => this.setLocalTyping(false), 4000);
+          const shouldSend = !this.lastTypingState || (now - this.lastTypingSentAt > 2000);
+          this.lastTypingState = true;
+          if (shouldSend) {
+            this.lastTypingSentAt = now;
+            this.announceTypingState(true);
+          }
+        } else {
+          if (this.typingResetTimer) {
+            clearTimeout(this.typingResetTimer);
+            this.typingResetTimer = null;
+          }
+          if (this.lastTypingState) {
+            this.lastTypingState = false;
+            this.lastTypingSentAt = now;
+            this.announceTypingState(false);
+          }
+        }
+      }
+
+      async announceTypingState(active) {
+        if (!this.conn || !CryptoManager.getCurrentKey()) {
+          return;
+        }
+
+        const profile = this.localIdentity || {};
+        const displayName = profile.displayName || 'You';
+        const avatar = this.normalizeAvatar(profile.avatar || this.computeAvatarFromName(displayName));
+        const userId = profile.id || this.localUserId;
+
+        await this.sendSecureControlMessage({
+          type: 'typing_state',
+          active: Boolean(active),
+          userId,
+          displayName,
+          avatar,
+          timestamp: Date.now()
+        });
+      }
+
+      handleTypingControl(message) {
+        if (!message || typeof message !== 'object') {
+          return;
+        }
+
+        const userId = message.userId || this.remoteIdentity?.id || this.remoteUserId;
+        if (!userId) {
+          return;
+        }
+        if (userId === this.localUserId || (this.localIdentity && userId === this.localIdentity.id)) {
+          return;
+        }
+
+        if (!this.typingUsers) {
+          this.typingUsers = new Map();
+        }
+        if (!this.typingTimeouts) {
+          this.typingTimeouts = new Map();
+        }
+
+        const isActive = Boolean(message.active);
+        if (isActive) {
+          const displayName = typeof message.displayName === 'string'
+            ? message.displayName
+            : (this.remoteIdentity?.displayName || 'Guest');
+          const avatar = this.normalizeAvatar(message.avatar || this.remoteIdentity?.avatar);
+          if (this.typingTimeouts.has(userId)) {
+            clearTimeout(this.typingTimeouts.get(userId));
+            this.typingTimeouts.delete(userId);
+          }
+          this.typingUsers.set(userId, {
+            id: userId,
+            displayName,
+            avatar
+          });
+          const timeout = setTimeout(() => this.clearTypingUser(userId), 5000);
+          this.typingTimeouts.set(userId, timeout);
+          this.renderTypingIndicator(Array.from(this.typingUsers.values()));
+        } else {
+          this.clearTypingUser(userId);
+        }
+      }
+
+      clearTypingUser(userId) {
+        if (!userId || !this.typingUsers) {
+          return;
+        }
+        if (this.typingTimeouts?.has(userId)) {
+          clearTimeout(this.typingTimeouts.get(userId));
+          this.typingTimeouts.delete(userId);
+        }
+        const removed = this.typingUsers.delete(userId);
+        if (removed) {
+          this.renderTypingIndicator(Array.from(this.typingUsers.values()));
+        }
+      }
+
+      clearTypingState() {
+        if (this.typingResetTimer) {
+          clearTimeout(this.typingResetTimer);
+          this.typingResetTimer = null;
+        }
+        if (this.typingTimeouts) {
+          for (const timeout of this.typingTimeouts.values()) {
+            clearTimeout(timeout);
+          }
+          this.typingTimeouts.clear();
+        }
+        this.typingUsers?.clear?.();
+        this.lastTypingState = false;
+        this.lastTypingSentAt = 0;
+        this.renderTypingIndicator([]);
+      }
+
+      getTypingIndicatorText(users) {
+        if (!Array.isArray(users) || users.length === 0) {
+          return 'Someone is typing';
+        }
+        const names = users
+          .map((user) => (typeof user.displayName === 'string' && user.displayName.trim() ? user.displayName.trim() : 'Someone'));
+        if (names.length === 1) {
+          return `${names[0]} is typing`;
+        }
+        if (names.length === 2) {
+          return `${names[0]} and ${names[1]} are typing`;
+        }
+        return `${names.length} people are typing`;
+      }
+
+      renderTypingIndicator(users) {
+        const indicator = this.typingIndicator || DOM.typingIndicator;
+        if (!indicator) {
+          return;
+        }
+
+        const list = Array.isArray(users) ? users.filter(Boolean) : [];
+        if (list.length === 0) {
+          indicator.innerHTML = '';
+          indicator.setAttribute('hidden', '');
+          return;
+        }
+
+        const limited = list.slice(0, 3);
+        const avatarHtml = limited.map((user) => {
+          const palette = this.getAvatarPalette(user);
+          const emoji = typeof user?.avatar?.emoji === 'string' && user.avatar.emoji.trim()
+            ? user.avatar.emoji
+            : '🙂';
+          return `<span class="typing-avatar" style="--avatar-color-1:${palette.primary}; --avatar-color-2:${palette.secondary};">${this.escapeHtml(emoji)}</span>`;
+        }).join('');
+
+        const text = this.getTypingIndicatorText(list);
+        indicator.innerHTML = `
+          <div class="typing-avatars">${avatarHtml}</div>
+          <div class="typing-text">${this.escapeHtml(text)}</div>
+          <div class="typing-dots"><span></span><span></span><span></span></div>
+        `;
+        indicator.removeAttribute('hidden');
       }
 
       getMessageStateDots(state) {

--- a/index.html
+++ b/index.html
@@ -194,6 +194,8 @@
             <!-- Messages will appear here -->
           </div>
 
+          <div id="typingIndicator" class="typing-indicator-bar" hidden></div>
+
           <div class="chat-input-container">
             <div class="chat-input-wrapper">
               <input type="text" id="messageInput" class="chat-input" placeholder="Type a secure message...">

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -70,7 +70,18 @@ const projection = {
           (message.sentAtLocal ?? message.at) + skewAllowance
         ),
         localOrder: message.localOrder || 0,
-        editedAt: message.editedAt
+        editedAt: message.editedAt,
+        userId: message.userId,
+        displayName: message.displayName,
+        avatar: message.avatar,
+        hops: Number.isFinite(message.hops) ? message.hops : 1,
+        routePath: Array.isArray(message.routePath) ? [...message.routePath] : [],
+        arrivalTime: message.arrivalTime,
+        state: message.state,
+        vectorClock: message.vectorClock && typeof message.vectorClock === 'object' ? { ...message.vectorClock } : {},
+        sequence: message.sequence,
+        originalPosition: message.originalPosition,
+        isOutOfOrder: Boolean(message.isOutOfOrder)
       });
     }
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -286,6 +286,12 @@ function setupConnection(app, conn) {
       const vectorClock = parsed?.vectorClock && typeof parsed.vectorClock === 'object'
         ? parsed.vectorClock
         : (typeof app.buildVectorClock === 'function' ? app.buildVectorClock(sequence, actor) : {});
+      const remoteDisplayName = typeof app.remoteIdentity?.displayName === 'string'
+        ? app.remoteIdentity.displayName
+        : 'Guest';
+      const remoteAvatar = typeof app.normalizeAvatar === 'function'
+        ? app.normalizeAvatar(app.remoteIdentity?.avatar)
+        : { emoji: '🙂', color: '#4A9FD5' };
       await publish(
         makeEvent(
           'MessagePosted',
@@ -305,7 +311,9 @@ function setupConnection(app, conn) {
             vectorClock,
             sequence,
             originalPosition: wasOutOfOrder ? arrivalIndex : null,
-            isOutOfOrder: wasOutOfOrder
+            isOutOfOrder: wasOutOfOrder,
+            displayName: remoteDisplayName,
+            avatar: remoteAvatar
           },
           actor,
           [`room:${app.roomId}`, `msg:${messageId}`]

--- a/lib/state.js
+++ b/lib/state.js
@@ -9,6 +9,15 @@ class ChatState {
   }
 }
 
+function normalizeAvatar(avatar) {
+  if (!avatar || typeof avatar !== 'object') {
+    return { emoji: '🙂', color: '#4A9FD5' };
+  }
+  const emoji = typeof avatar.emoji === 'string' ? avatar.emoji : '🙂';
+  const color = typeof avatar.color === 'string' ? avatar.color : '#4A9FD5';
+  return { emoji, color };
+}
+
 function ensureRoom(state, roomId, defaults = {}) {
   if (!state.rooms.has(roomId)) {
     state.rooms.set(roomId, {
@@ -80,7 +89,9 @@ function reduce(state, event) {
         vectorClock,
         sequence,
         originalPosition,
-        isOutOfOrder
+        isOutOfOrder,
+        displayName,
+        avatar
       } = payload;
       const room = ensureRoom(state, roomId);
       const now = Date.now();
@@ -100,6 +111,11 @@ function reduce(state, event) {
       state.messageClock = (state.messageClock || 0) + 1;
       const order = state.byRoom.get(roomId) || [];
       const arrivalIndex = order.length;
+      const normalizedName = typeof displayName === 'string' && displayName.trim()
+        ? displayName.trim()
+        : (messageType === 'me' ? 'You' : 'Guest');
+      const normalizedAvatar = normalizeAvatar(avatar);
+
       const message = {
         id: messageId,
         roomId,
@@ -121,6 +137,8 @@ function reduce(state, event) {
         sequence: Number.isFinite(sequence) ? sequence : null,
         originalPosition: Number.isFinite(originalPosition) ? originalPosition : null,
         isOutOfOrder: Boolean(isOutOfOrder),
+        displayName: normalizedName,
+        avatar: normalizedAvatar,
         arrivalIndex
       };
       state.messages.set(messageId, message);

--- a/styles.css
+++ b/styles.css
@@ -535,6 +535,7 @@
       display: flex;
       flex-direction: column;
       min-height: 0;
+      position: relative;
     }
 
     .chat-header {
@@ -724,10 +725,10 @@
     .chat-messages {
       flex: 1;
       overflow-y: auto;
-      padding: 1.5rem;
+      padding: 1.75rem 1.5rem 3.75rem;
       display: flex;
       flex-direction: column;
-      gap: 1rem;
+      gap: 0;
       scroll-behavior: smooth;
     }
 
@@ -745,14 +746,157 @@
     }
 
     .message {
-      display: flex;
-      align-items: flex-end;
-      gap: 0.5rem;
-      animation: messageIn 0.3s ease;
       position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      margin-bottom: 2px;
+      animation: message-slide-in 0.3s ease-out;
     }
 
-    @keyframes messageIn {
+    .message:not([data-consecutive="true"]) {
+      margin-top: 16px;
+    }
+
+    .message.local {
+      align-items: flex-end;
+    }
+
+    .message.remote {
+      align-items: flex-start;
+    }
+
+    .sender-header {
+      display: flex;
+      align-items: baseline;
+      gap: 8px;
+      margin-bottom: 4px;
+      padding-left: 48px;
+      position: relative;
+      width: 100%;
+    }
+
+    .message.local .sender-header {
+      justify-content: flex-end;
+      padding-left: 0;
+      padding-right: 12px;
+    }
+
+    .sender-avatar {
+      width: 32px;
+      height: 32px;
+      border-radius: 8px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: linear-gradient(135deg, var(--avatar-color-1, #334155), var(--avatar-color-2, #0f172a));
+      font-size: 1rem;
+      color: #ffffff;
+      position: absolute;
+      left: 12px;
+      top: 0;
+    }
+
+    .sender-name {
+      font-weight: 600;
+      font-size: 0.85rem;
+      color: #e2e8f0;
+    }
+
+    .sender-time {
+      font-size: 0.7rem;
+      color: #94a3b8;
+    }
+
+    .message-content-wrapper {
+      position: relative;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .message.local .message-content-wrapper {
+      align-items: flex-end;
+    }
+
+    .sender-tooltip {
+      position: absolute;
+      left: 12px;
+      top: 50%;
+      transform: translateY(-50%);
+      background: rgba(15, 23, 42, 0.92);
+      color: #f8fafc;
+      padding: 4px 8px;
+      border-radius: 6px;
+      font-size: 0.7rem;
+      white-space: nowrap;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.2s ease;
+      z-index: 5;
+    }
+
+    .message:hover .sender-tooltip {
+      opacity: 1;
+    }
+
+    .message-bubble {
+      position: relative;
+      background: rgba(15, 23, 42, 0.7);
+      border: 1px solid rgba(148, 163, 184, 0.14);
+      border-radius: 18px;
+      padding: 0.9rem 1.1rem;
+      box-shadow: 0 18px 40px rgba(2, 6, 23, 0.55);
+      max-width: min(70%, 520px);
+      margin-left: 48px;
+      color: var(--text-primary);
+    }
+
+    .message.remote[data-consecutive="true"] .message-bubble {
+      margin-top: 2px;
+    }
+
+    .message.local .message-bubble {
+      background: linear-gradient(135deg, #2563eb, #1d4ed8);
+      border: none;
+      margin-left: auto;
+      margin-right: 12px;
+      color: #f8fafc;
+    }
+
+    .message-text {
+      font-size: 0.95rem;
+      line-height: 1.55;
+      word-break: break-word;
+    }
+
+    .message-meta {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.7rem;
+      margin-top: 0.5rem;
+      color: #94a3b8;
+    }
+
+    .message.local .message-meta {
+      justify-content: flex-end;
+      color: rgba(226, 232, 240, 0.8);
+    }
+
+    .delivery-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 0.75rem;
+    }
+
+    .timestamp {
+      white-space: nowrap;
+    }
+
+    @keyframes message-slide-in {
       from {
         opacity: 0;
         transform: translateY(10px);
@@ -763,52 +907,10 @@
       }
     }
 
-    .message.me {
-      flex-direction: row-reverse;
-    }
-
-    .message-content {
-      max-width: 70%;
-      padding: 0.875rem 1.25rem;
-      background: var(--message-bg);
-      border-radius: 18px 18px 18px 4px;
-      word-wrap: break-word;
-      position: relative;
-    }
-
-    .message.me .message-content {
-      background: var(--message-me);
-      border-radius: 18px 18px 4px 18px;
-    }
-
-    .message-text {
-      font-size: 0.95rem;
-      line-height: 1.5;
-    }
-
-    .message-meta {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      font-size: 0.7rem;
-      opacity: 0.6;
-      margin-top: 0.25rem;
-    }
-
-    .timestamp {
-      white-space: nowrap;
-    }
-
-    .state-dots {
-      letter-spacing: 2px;
-      font-weight: 600;
-      white-space: nowrap;
-    }
-
     .reorder-badge {
       position: absolute;
-      top: -8px;
-      right: 10px;
+      top: -12px;
+      right: 18px;
       background: linear-gradient(135deg, #f59e0b, #d97706);
       color: white;
       border: none;
@@ -828,6 +930,112 @@
     .reorder-badge:hover {
       transform: scale(1.1);
       box-shadow: 0 2px 8px rgba(245, 158, 11, 0.4);
+    }
+
+    .time-break {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin: 24px 0;
+      padding: 0 20px;
+      color: #94a3b8;
+    }
+
+    .time-break-line {
+      flex: 1;
+      height: 1px;
+      background: rgba(148, 163, 184, 0.25);
+    }
+
+    .time-break-text {
+      font-size: 0.75rem;
+      font-weight: 500;
+      background: rgba(15, 23, 42, 0.85);
+      padding: 2px 12px;
+      border-radius: 999px;
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      color: #cbd5f5;
+    }
+
+    .typing-indicator-bar {
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 72px;
+      padding: 10px 24px;
+      background: rgba(15, 23, 42, 0.92);
+      border-top: 1px solid rgba(148, 163, 184, 0.18);
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 0.8rem;
+      color: #94a3b8;
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      transition: opacity 0.2s ease;
+    }
+
+    .typing-indicator-bar[hidden] {
+      display: none;
+    }
+
+    .typing-avatars {
+      display: flex;
+      align-items: center;
+      margin-left: -4px;
+    }
+
+    .typing-avatar {
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, var(--avatar-color-1, #334155), var(--avatar-color-2, #0f172a));
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.75rem;
+      margin-left: -4px;
+      border: 2px solid rgba(15, 23, 42, 0.92);
+      color: #f8fafc;
+    }
+
+    .typing-text {
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .typing-dots {
+      display: flex;
+      gap: 4px;
+    }
+
+    .typing-dots span {
+      width: 5px;
+      height: 5px;
+      background: #94a3b8;
+      border-radius: 50%;
+      animation: typing-bounce 1.4s infinite;
+    }
+
+    .typing-dots span:nth-child(2) {
+      animation-delay: 0.2s;
+    }
+
+    .typing-dots span:nth-child(3) {
+      animation-delay: 0.4s;
+    }
+
+    @keyframes typing-bounce {
+      0%, 60%, 100% {
+        transform: translateY(0);
+        opacity: 0.45;
+      }
+      30% {
+        transform: translateY(-4px);
+        opacity: 1;
+      }
     }
 
     .badge-icon {
@@ -1726,8 +1934,25 @@
         grid-template-columns: 1fr;
       }
 
-      .message-content {
+      .sender-header {
+        padding-left: 40px;
+      }
+
+      .sender-avatar {
+        width: 28px;
+        height: 28px;
+        left: 8px;
+        font-size: 0.9rem;
+      }
+
+      .message.remote .message-bubble {
         max-width: 85%;
+        margin-left: 40px;
+      }
+
+      .typing-indicator-bar {
+        bottom: 66px;
+        padding: 8px 16px;
       }
 
       .room-code-display {
@@ -1772,7 +1997,21 @@
       }
 
       .chat-messages {
-        padding: 1rem;
+        padding: 1.25rem 1rem 3.25rem;
+      }
+
+      .sender-header {
+        padding-left: 36px;
+      }
+
+      .sender-avatar {
+        width: 26px;
+        height: 26px;
+        left: 6px;
+      }
+
+      .message.remote .message-bubble {
+        margin-left: 36px;
       }
 
       .chat-input-container {


### PR DESCRIPTION
## Summary
- enrich stored chat events with sender metadata and propagate it through projections so grouped message headers can display avatars and names
- restyle the chat timeline to group consecutive messages, add time breaks, compact timestamps, and delivery status icons
- add typing presence support with secure control messages and surface a multi-user typing indicator in the UI

## Testing
- node tests/replay.js
- node tests/fuzz.js
- node tests/crypto.spec.js

------
https://chatgpt.com/codex/tasks/task_b_68d46e810a0083329d6fb44f6b178fa2