### PR TITLE
Improve host/join UX with manual invite entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,15 +59,52 @@
             </div>
           </div>
 
-          <div class="action-buttons">
-            <button class="btn btn-primary" onclick="App.showHost()">
-              <span>🏠</span>
-              <span>Create Room</span>
-            </button>
-            <button class="btn btn-secondary" onclick="App.showJoin()">
-              <span>🔗</span>
-              <span>Join Room</span>
-            </button>
+          <div class="welcome-actions">
+            <div class="welcome-action host-action">
+              <h2>Start a room</h2>
+              <p>Create a private space and invite people you trust. No accounts, no history.</p>
+              <div class="setup-steps compact">
+                <div class="setup-step">
+                  <div class="step-number">1</div>
+                  <div>
+                    <h3>Generate your room</h3>
+                    <p>We’ll create a fresh room ID every time you start.</p>
+                  </div>
+                </div>
+                <div class="setup-step">
+                  <div class="step-number">2</div>
+                  <div>
+                    <h3>Share the invite</h3>
+                    <p>Send the one-time link or read the code aloud.</p>
+                  </div>
+                </div>
+                <div class="setup-step">
+                  <div class="step-number">3</div>
+                  <div>
+                    <h3>Start chatting</h3>
+                    <p>Your conversation stays end-to-end encrypted.</p>
+                  </div>
+                </div>
+              </div>
+              <button id="welcomeHostBtn" class="btn btn-primary">
+                <span>🏠</span>
+                <span>Start a room</span>
+              </button>
+            </div>
+            <div class="welcome-action join-action">
+              <h2>Join a room</h2>
+              <p>Paste the link or code your host sent you to hop in.</p>
+              <form id="welcomeJoinForm" class="inline-join-form" novalidate>
+                <label class="sr-only" for="welcomeJoinInput">Invite link or code</label>
+                <input id="welcomeJoinInput" class="input-field" type="text" placeholder="Paste invite link or code" autocomplete="off">
+                <button id="welcomeJoinBtn" class="btn btn-secondary" type="submit">
+                  <span>🔗</span>
+                  <span>Join</span>
+                </button>
+              </form>
+              <div id="welcomeJoinFeedback" class="input-feedback" aria-live="polite"></div>
+              <button id="welcomeJoinHelp" class="ghost-link" type="button">Need help? View join instructions</button>
+            </div>
           </div>
 
           <!-- Room History -->
@@ -90,7 +127,24 @@
             Loading...
           </div>
           
-          <button class="btn btn-primary" style="width: 100%;" onclick="App.startHost()">
+          <div class="setup-steps">
+            <div class="setup-step">
+              <div class="step-number">1</div>
+              <div>
+                <h3>Confirm the room code</h3>
+                <p>Share it verbally if you’re already on a call together.</p>
+              </div>
+            </div>
+            <div class="setup-step">
+              <div class="step-number">2</div>
+              <div>
+                <h3>Send a one-time link</h3>
+                <p>Generate a private link that expires after it’s used.</p>
+              </div>
+            </div>
+          </div>
+
+          <button class="btn btn-primary full-width" onclick="App.startHost()">
             Generate Secure Invite
           </button>
 
@@ -138,6 +192,19 @@
             <div class="spinner" id="joinSpinner"></div>
             <p id="joinStatus" tabindex="-1">Claiming your secure seat...</p>
             <p class="small" id="joinStatusDetail">Verifying one-time token...</p>
+          </div>
+
+          <div class="manual-join-card">
+            <h3>Join with a link or code</h3>
+            <form id="joinLinkForm" class="manual-join-form" novalidate>
+              <label class="input-label" for="joinLinkInput">Invite link or code</label>
+              <div class="input-row">
+                <input type="text" id="joinLinkInput" class="input-field" placeholder="Paste invite link or code" autocomplete="off">
+                <button id="joinLinkBtn" class="btn btn-primary" type="submit">Join Room</button>
+              </div>
+            </form>
+            <div id="joinManualError" class="input-feedback" aria-live="polite"></div>
+            <p class="small muted">Tip: Links usually look like <code>https://your-chat.app#/j/abc123</code>. They can only be used once.</p>
           </div>
           
           <button class="btn btn-secondary" style="width: 100%; margin-top: 1rem;" onclick="App.showWelcome()">

--- a/styles.css
+++ b/styles.css
@@ -276,6 +276,93 @@
       line-height: 1.6;
     }
 
+    .welcome-actions {
+      display: grid;
+      gap: 1.5rem;
+      margin-top: 2.5rem;
+      width: 100%;
+    }
+
+    .welcome-action {
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 18px;
+      padding: 1.75rem;
+      text-align: left;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      transition: border-color 0.3s ease, transform 0.3s ease;
+    }
+
+    .welcome-action:hover {
+      border-color: rgba(0, 102, 255, 0.3);
+      transform: translateY(-4px);
+    }
+
+    .welcome-action h2 {
+      margin: 0;
+      font-size: 1.5rem;
+    }
+
+    .welcome-action p {
+      margin: 0;
+      color: var(--text-secondary);
+      line-height: 1.5;
+    }
+
+    .welcome-action .btn {
+      align-self: flex-start;
+    }
+
+    .inline-join-form {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .inline-join-form .input-field {
+      flex: 1;
+    }
+
+    .input-feedback {
+      font-size: 0.9rem;
+      color: var(--text-secondary);
+      min-height: 1.2rem;
+      margin-top: 0.25rem;
+    }
+
+    .input-feedback.error {
+      color: var(--error);
+    }
+
+    .ghost-link {
+      background: none;
+      border: none;
+      color: var(--accent);
+      font-size: 0.95rem;
+      font-weight: 600;
+      padding: 0;
+      text-decoration: underline;
+      cursor: pointer;
+      align-self: flex-start;
+    }
+
+    .ghost-link:hover {
+      color: var(--accent-hover);
+    }
+
+    @media (min-width: 768px) {
+      .welcome-actions {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .inline-join-form {
+        flex-direction: row;
+        align-items: center;
+      }
+    }
+
     .features {
       display: grid;
       grid-template-columns: repeat(3, 1fr);
@@ -325,6 +412,15 @@
       -webkit-tap-highlight-color: transparent;
     }
 
+    .btn.full-width {
+      width: 100%;
+    }
+
+    .btn.loading {
+      opacity: 0.7;
+      cursor: wait;
+    }
+
     .btn-primary {
       background: var(--accent);
       color: white;
@@ -368,6 +464,50 @@
       width: 100%;
       box-shadow: var(--shadow);
       animation: fadeInUp 0.5s ease;
+    }
+
+    .setup-steps {
+      display: grid;
+      gap: 1rem;
+      margin: 2rem 0 1.5rem;
+    }
+
+    .setup-steps.compact {
+      margin: 0 0 1.5rem;
+    }
+
+    .setup-step {
+      display: flex;
+      gap: 1rem;
+      background: rgba(255, 255, 255, 0.04);
+      border-radius: 12px;
+      padding: 1rem;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
+    .setup-step h3 {
+      margin: 0;
+      font-size: 1.05rem;
+    }
+
+    .setup-step p {
+      margin: 0.25rem 0 0;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+      line-height: 1.4;
+    }
+
+    .step-number {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      background: var(--accent);
+      color: #fff;
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
     }
 
     .room-code-display {
@@ -501,6 +641,53 @@
       align-items: center;
       gap: 0.75rem;
       text-align: center;
+    }
+
+    .manual-join-card {
+      margin-top: 2rem;
+      width: 100%;
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 16px;
+      padding: 1.5rem;
+      text-align: left;
+    }
+
+    .manual-join-card h3 {
+      margin: 0 0 1rem;
+      font-size: 1.25rem;
+    }
+
+    .manual-join-form {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .input-row {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    .input-row .input-field {
+      flex: 1;
+      min-width: 220px;
+    }
+
+    .small.muted {
+      color: var(--text-secondary);
+      margin-top: 1rem;
+    }
+
+    .small.muted code {
+      background: var(--bg-primary);
+      padding: 0.2rem 0.4rem;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      color: var(--text-primary);
+      font-size: 0.85rem;
     }
 
     .joining-status .spinner {


### PR DESCRIPTION
## Summary
- redesign the welcome screen to feature clear "Start a room" and inline "Join a room" flows
- expand the host setup view with step-by-step guidance and a full-width invite action
- add a manual join form that parses invite links/codes and wires new feedback handling in the app

## Testing
- node tests/crypto.spec.js

------
https://chatgpt.com/codex/tasks/task_b_68d470521de48332aacbd43c63c88f84