### PR TITLE
Revamp invite flow with seat visual and share options

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,26 +96,59 @@
 
           <div id="shareSection" class="share-section" style="display: none;">
             <div class="invite-section" id="inviteSection">
-              <h3>🎟️ Secure One-Time Invite</h3>
-              <p>This link works only once and expires in 15 minutes.</p>
+              <div class="invite-generator">
+                <div class="invite-header">
+                  <h3>Invite Someone to This Room</h3>
+                  <p class="invite-note">Each invite works once and expires in 15 minutes.</p>
+                </div>
 
-              <div class="invite-link-container">
-                <input id="inviteLink" class="invite-input" readonly value="Generating secure link..." aria-live="polite">
-                <button id="copyInviteBtn" class="btn btn-primary">📋 Copy Secure Link</button>
-              </div>
+                <div class="room-seats-visual">
+                  <div class="seats-grid" id="inviteSeatsGrid"></div>
+                  <p class="seats-info" id="inviteSeatsInfo">Seats loading…</p>
+                </div>
 
-              <div class="security-info">
-                ✅ No passwords needed<br>
-                ✅ Single-use only<br>
-                ✅ Auto-expires<br>
-                ✅ Cryptographically secure
-              </div>
+                <div class="invite-actions">
+                  <button id="generateInviteBtn" class="btn btn-primary">
+                    <span aria-hidden="true">🎟️</span>
+                    <span>Generate Invite Link</span>
+                  </button>
+                  <p class="invite-note subtle">Need a fresh link? Generate a new one anytime.</p>
+                </div>
 
-              <div class="simple-setup">
-                <label class="input-label" for="simpleEmail">Simple setup (optional)</label>
-                <input type="email" id="simpleEmail" class="input-field" placeholder="Invite email (leave blank to use device share)">
-                <button class="btn btn-secondary" style="width: 100%;" onclick="App.simpleShareInvite()">✨ Simple Setup: Share Invite</button>
-                <div id="simpleShareStatus" class="simple-status"></div>
+                <div class="active-invite" id="activeInvite" hidden>
+                  <div class="invite-status">
+                    <span class="status-dot pulse" id="inviteStatusDot" aria-hidden="true"></span>
+                    <span id="inviteCountdown">No active invite</span>
+                  </div>
+
+                  <div class="invite-link-box">
+                    <input id="inviteLink" class="invite-input" readonly value="Generating secure link..." aria-live="polite">
+                    <button id="copyInviteBtn" class="btn btn-secondary" disabled>📋 Copy Secure Link</button>
+                  </div>
+
+                  <div class="invite-options">
+                    <button class="btn btn-ghost" id="shareInviteBtn" disabled>
+                      📱 Share Options
+                    </button>
+                    <button class="btn btn-ghost" id="cancelInviteBtn" disabled>
+                      ❌ Cancel Invite
+                    </button>
+                  </div>
+                </div>
+
+                <div class="security-info">
+                  ✅ No passwords needed<br>
+                  ✅ Single-use only<br>
+                  ✅ Auto-expires<br>
+                  ✅ Cryptographically secure
+                </div>
+
+                <div class="simple-setup">
+                  <label class="input-label" for="simpleEmail">Simple setup (optional)</label>
+                  <input type="email" id="simpleEmail" class="input-field" placeholder="Invite email (leave blank to use device share)">
+                  <button class="btn btn-secondary" style="width: 100%;" onclick="App.simpleShareInvite()">✨ Simple Setup: Share Invite</button>
+                  <div id="simpleShareStatus" class="simple-status"></div>
+                </div>
               </div>
             </div>
           </div>

--- a/lib/net.js
+++ b/lib/net.js
@@ -87,6 +87,9 @@ function initPeer(app, id) {
           SecureInvite.generateSeat()
         ]);
         app.seats = { host: hostSeat, guest: guestSeat };
+        if (typeof app.updateInviteVisuals === 'function') {
+          app.updateInviteVisuals();
+        }
         const seatSalt = SecureInvite.fromBase64Url(guestSeat.seatId);
         if (!(seatSalt instanceof Uint8Array)) {
           throw new Error('Invalid regenerated seat');
@@ -155,6 +158,9 @@ function setupConnection(app, conn) {
       } catch (error) {
         console.warn('Unable to persist guest invite claim.', error);
       }
+    }
+    if (typeof app.updateInviteVisuals === 'function') {
+      app.updateInviteVisuals();
     }
     const fingerprint = CryptoManager.getFingerprint();
     if (fingerprint) {
@@ -334,6 +340,9 @@ function setupConnection(app, conn) {
     if (typeof app.showToast === 'function') {
       app.showToast(app.isHost ? 'Guest disconnected' : 'Disconnected from host', app.isHost ? 'warning' : 'error');
     }
+    if (typeof app.updateInviteVisuals === 'function') {
+      app.updateInviteVisuals();
+    }
     if (app.isHost) {
       app.updateStatus('Waiting for peer...', 'connecting');
       const link = await app.refreshGuestInvite({
@@ -364,6 +373,9 @@ function setupConnection(app, conn) {
     app.addSystemMessage('⚠️ Connection error occurred');
     if (typeof app.showToast === 'function') {
       app.showToast('Connection error', 'error');
+    }
+    if (typeof app.updateInviteVisuals === 'function') {
+      app.updateInviteVisuals();
     }
     if (app.isHost) {
       app.updateStatus('Waiting for peer...', 'connecting');

--- a/styles.css
+++ b/styles.css
@@ -431,19 +431,234 @@
     .invite-section {
       display: flex;
       flex-direction: column;
-      gap: 1rem;
+      gap: 1.5rem;
     }
 
-    .invite-section h3 {
+    .invite-generator {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    .invite-header h3 {
       margin: 0;
-      font-size: 1.25rem;
+      font-size: 1.35rem;
       font-weight: 600;
     }
 
-    .invite-link-container {
+    .invite-note {
+      margin: 0.25rem 0 0;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+    }
+
+    .invite-note.subtle {
+      font-size: 0.85rem;
+      margin-top: 0.5rem;
+    }
+
+    .room-seats-visual {
+      background: rgba(0, 0, 0, 0.2);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 14px;
+      padding: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .seats-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 1rem;
+    }
+
+    .seat {
+      border-radius: 12px;
+      padding: 0.85rem;
+      background: rgba(13, 18, 28, 0.8);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      align-items: flex-start;
+      min-height: 110px;
+      position: relative;
+    }
+
+    .seat::after {
+      content: attr(data-role);
+      position: absolute;
+      top: 0.55rem;
+      right: 0.75rem;
+      font-size: 0.65rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.4);
+    }
+
+    .seat.occupied {
+      border-color: rgba(0, 153, 255, 0.45);
+      background: rgba(0, 102, 255, 0.12);
+    }
+
+    .seat.reserved {
+      border-style: dashed;
+      border-color: rgba(255, 255, 255, 0.18);
+    }
+
+    .seat.available {
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      border-style: dashed;
+      color: var(--text-secondary);
+    }
+
+    .seat-avatar {
+      width: 48px;
+      height: 48px;
+      border-radius: 12px;
+      background: rgba(0, 102, 255, 0.25);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.5rem;
+    }
+
+    .seat-name {
+      font-weight: 600;
+      font-size: 1rem;
+      color: var(--text-primary);
+    }
+
+    .seat-label {
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+    }
+
+    .seat-sub-label {
+      font-size: 0.75rem;
+      color: rgba(255, 255, 255, 0.6);
+    }
+
+    .empty-seat {
+      width: 42px;
+      height: 42px;
+      border-radius: 50%;
+      border: 1px dashed rgba(255, 255, 255, 0.35);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.3rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .seats-info {
+      margin: 0;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+    }
+
+    .invite-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .invite-actions button {
+      width: 100%;
+      justify-content: center;
+      gap: 0.5rem;
+    }
+
+    .active-invite {
+      border-radius: 12px;
+      background: rgba(0, 102, 255, 0.12);
+      border: 1px solid rgba(0, 102, 255, 0.35);
+      padding: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .active-invite[hidden] {
+      display: none;
+    }
+
+    .active-invite.expired {
+      border-style: dashed;
+      border-color: rgba(255, 105, 105, 0.45);
+      background: rgba(255, 105, 105, 0.12);
+    }
+
+    .invite-status {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+    }
+
+    .active-invite.expired .invite-status {
+      color: var(--error);
+    }
+
+    .status-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--success);
+      display: inline-block;
+      position: relative;
+    }
+
+    .status-dot.pulse::after {
+      content: '';
+      position: absolute;
+      inset: -4px;
+      border-radius: 50%;
+      border: 2px solid rgba(0, 153, 255, 0.35);
+      animation: pulse 1.8s ease-out infinite;
+    }
+
+    .invite-link-box {
       display: flex;
       gap: 0.75rem;
       align-items: center;
+      flex-wrap: wrap;
+    }
+
+    .invite-link-box .invite-input {
+      flex: 1 1 240px;
+      min-width: 0;
+    }
+
+    .invite-options {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    .btn-ghost {
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 10px;
+      padding: 0.65rem 1rem;
+      color: var(--text-secondary);
+      font-weight: 500;
+      transition: all 0.2s ease;
+    }
+
+    .btn-ghost:hover:not(:disabled) {
+      color: var(--text-primary);
+      border-color: rgba(0, 153, 255, 0.45);
+      background: rgba(0, 102, 255, 0.18);
+    }
+
+    .btn-ghost:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
     }
 
     .invite-input {


### PR DESCRIPTION
## Summary
- replace the host invite section with a clearer generator that visualises room seats, shows the active link, and offers share/cancel controls
- add invite management logic for countdowns, seat rendering, and share options while keeping the UI in sync with identity and connection state
- update peer connection handlers so invite visuals stay accurate through connection, disconnection, and regeneration flows

## Testing
- node tests/crypto.spec.js
- node tests/fuzz.js

------
https://chatgpt.com/codex/tasks/task_b_68d46eca44108332a47eaf5bff6df8ca