### PR TITLE
Revamp identity onboarding flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,18 +36,27 @@ const DOM = {
   identityCreateForm: document.getElementById('identityCreateForm'),
   identitySuggestions: document.getElementById('identitySuggestions'),
   identityNameInput: document.getElementById('identityNameInput'),
-  identityRefreshBtn: document.getElementById('identityRefreshBtn'),
   identityPasswordInput: document.getElementById('identityPasswordInput'),
   identityStrengthBar: document.getElementById('identityStrengthBar'),
   identityStrengthText: document.getElementById('identityStrengthText'),
+  identityPasswordSection: document.getElementById('identityPasswordSection'),
+  identityStepName: document.getElementById('identityStepName'),
+  identityStepPassword: document.getElementById('identityStepPassword'),
   identityModeCreate: document.getElementById('identityModeCreate'),
   identityModeReturning: document.getElementById('identityModeReturning'),
   identityReturningForm: document.getElementById('identityReturningForm'),
   identityReturningPassword: document.getElementById('identityReturningPassword'),
   identityModalTitle: document.getElementById('identityModalTitle'),
   identityModalSubtitle: document.getElementById('identityModalSubtitle'),
-  identityHint: document.getElementById('identityHint'),
-  identityUseNew: document.getElementById('identityUseNew'),
+  identityShowReturning: document.getElementById('identityShowReturning'),
+  identityReturningTitle: document.getElementById('identityReturningTitle'),
+  identityReturningSubtitle: document.getElementById('identityReturningSubtitle'),
+  identityReturningName: document.getElementById('identityReturningName'),
+  identityReturningAvatar: document.getElementById('identityReturningAvatar'),
+  identityReturningLastSeen: document.getElementById('identityReturningLastSeen'),
+  identityJoinNew: document.getElementById('identityJoinNew'),
+  identityForgotPassword: document.getElementById('identityForgotPassword'),
+  identityReturningSubmitBtn: document.getElementById('identityReturningSubmitBtn'),
   identityError: document.getElementById('identityError'),
   identitySubmitBtn: document.getElementById('identitySubmitBtn'),
   reentryContainer: document.getElementById('reentryContainer')
@@ -1478,20 +1487,10 @@ class SecureChat {
           });
         }
 
-        if (DOM.identityRefreshBtn) {
-          DOM.identityRefreshBtn.addEventListener('click', (event) => {
-            event.preventDefault();
-            this.tryAnotherIdentitySuggestion({ resetHistory: true });
-          });
-          DOM.identityRefreshBtn.classList.add('sr-only');
-          DOM.identityRefreshBtn.setAttribute('aria-hidden', 'true');
-          DOM.identityRefreshBtn.setAttribute('tabindex', '-1');
-        }
-
         if (DOM.identityNameInput) {
           DOM.identityNameInput.addEventListener('input', () => {
             this.identitySelectedName = '';
-            this.updateJoinButtonText();
+            this.updateIdentityState();
             this.clearIdentityError();
             this.renderIdentitySelector();
           });
@@ -1500,6 +1499,7 @@ class SecureChat {
         if (DOM.identityPasswordInput) {
           DOM.identityPasswordInput.addEventListener('input', () => {
             this.updatePasswordStrength();
+            this.updateIdentityState();
             this.clearIdentityError();
           });
         }
@@ -1508,10 +1508,27 @@ class SecureChat {
           DOM.identityReturningPassword.addEventListener('input', () => this.clearIdentityError());
         }
 
-        if (DOM.identityUseNew) {
-          DOM.identityUseNew.addEventListener('click', () => {
+        if (DOM.identityShowReturning) {
+          DOM.identityShowReturning.addEventListener('click', (event) => {
+            event.preventDefault();
+            this.identityModalMode = 'returning';
+            this.showReturningIdentityFromCreate();
+          });
+        }
+
+        if (DOM.identityJoinNew) {
+          DOM.identityJoinNew.addEventListener('click', (event) => {
+            event.preventDefault();
+            this.identityModalMode = 'create';
             this.displayIdentityMode('create');
             this.refreshIdentitySuggestions(true);
+          });
+        }
+
+        if (DOM.identityForgotPassword) {
+          DOM.identityForgotPassword.addEventListener('click', (event) => {
+            event.preventDefault();
+            this.showIdentityError('Passwords never leave this device. Join as someone new to continue.');
           });
         }
 
@@ -1543,7 +1560,7 @@ class SecureChat {
         }
 
         if (force) {
-          this.updateJoinButtonText();
+          this.updateIdentityState();
           this.clearIdentityError();
         }
       }
@@ -1570,6 +1587,57 @@ class SecureChat {
         return { emoji, color };
       }
 
+      formatRelativeTime(timestamp) {
+        if (!timestamp) {
+          return 'just now';
+        }
+        const now = Date.now();
+        let diff = now - timestamp;
+        if (!Number.isFinite(diff) || diff < 0) {
+          diff = 0;
+        }
+        const minutes = Math.floor(diff / 60000);
+        if (minutes <= 0) {
+          return 'just now';
+        }
+        if (minutes === 1) {
+          return '1 minute ago';
+        }
+        if (minutes < 60) {
+          return `${minutes} minutes ago`;
+        }
+        const hours = Math.floor(minutes / 60);
+        if (hours === 1) {
+          return '1 hour ago';
+        }
+        if (hours < 24) {
+          return `${hours} hours ago`;
+        }
+        const days = Math.floor(hours / 24);
+        if (days === 1) {
+          return '1 day ago';
+        }
+        if (days < 7) {
+          return `${days} days ago`;
+        }
+        const weeks = Math.floor(days / 7);
+        if (weeks === 1) {
+          return '1 week ago';
+        }
+        if (weeks < 4) {
+          return `${weeks} weeks ago`;
+        }
+        const months = Math.floor(days / 30);
+        if (months === 1) {
+          return '1 month ago';
+        }
+        if (months < 12) {
+          return `${months} months ago`;
+        }
+        const years = Math.floor(days / 365);
+        return years === 1 ? '1 year ago' : `${years} years ago`;
+      }
+
       getSelectedDisplayName() {
         const custom = DOM.identityNameInput?.value?.trim();
         if (custom) {
@@ -1578,17 +1646,53 @@ class SecureChat {
         return this.identitySelectedName || '';
       }
 
-      updateJoinButtonText() {
+      updateIdentityState() {
         const button = DOM.identitySubmitBtn;
         const subtitle = DOM.identityModalSubtitle;
+        const passwordInput = DOM.identityPasswordInput;
+        const passwordSection = DOM.identityPasswordSection;
+        const stepName = DOM.identityStepName;
+        const stepPassword = DOM.identityStepPassword;
+        const bar = DOM.identityStrengthBar;
+        const text = DOM.identityStrengthText;
         const name = this.getSelectedDisplayName();
-        if (button) {
-          button.textContent = name ? `Join as ${name}` : 'Join Secure Room';
+        const hasName = Boolean(name);
+        const passwordValue = passwordInput?.value || '';
+
+        if (passwordInput) {
+          if (hasName) {
+            passwordInput.disabled = false;
+            passwordSection?.classList.remove('disabled');
+            stepPassword?.classList.add('active');
+            stepName?.classList.add('completed');
+          } else {
+            if (passwordValue) {
+              passwordInput.value = '';
+            }
+            passwordInput.disabled = true;
+            passwordSection?.classList.add('disabled');
+            stepPassword?.classList.remove('active');
+            stepName?.classList.remove('completed');
+            if (bar) {
+              bar.classList.add('hidden');
+              bar.style.setProperty('--strength', '0%');
+            }
+            if (text) {
+              text.classList.add('hidden');
+              text.textContent = 'Choose a strong password';
+            }
+          }
         }
+
+        if (button) {
+          button.disabled = !(hasName && passwordValue.length >= 8);
+          button.textContent = hasName ? `Continue as ${name}` : 'Continue to Room';
+        }
+
         if (subtitle) {
-          subtitle.textContent = name
-            ? `Secure your seat as ${name}`
-            : 'Secure your seat in this room';
+          subtitle.textContent = hasName
+            ? `Secure your identity as ${name}`
+            : 'Create your identity for this room';
         }
       }
 
@@ -1609,56 +1713,42 @@ class SecureChat {
         const suggestion = this.identityCurrentSuggestion || this.generateFallbackName();
         const avatar = this.computeAvatarFromName(suggestion);
         const isAccepted = this.identitySelectedName === suggestion;
-        const rejected = Array.isArray(this.identityRejectedNames)
-          ? this.identityRejectedNames
-          : [];
 
         container.innerHTML = '';
 
         const card = document.createElement('div');
-        card.className = 'name-selector-card';
+        card.className = 'suggested-name-card';
         if (isAccepted) {
           card.dataset.state = 'selected';
         }
 
-        const currentDisplay = document.createElement('div');
-        currentDisplay.className = 'current-name-display';
+        const preview = document.createElement('div');
+        preview.className = 'name-preview';
 
-        const avatarPreview = document.createElement('div');
+        const avatarPreview = document.createElement('span');
         avatarPreview.className = 'avatar-preview';
+        avatarPreview.textContent = avatar?.emoji || '🙂';
         if (avatar?.color) {
           avatarPreview.style.background = avatar.color;
+          avatarPreview.style.color = '#fff';
+        } else {
+          avatarPreview.style.color = '';
         }
-        avatarPreview.textContent = avatar?.emoji || '🙂';
 
-        const namePreview = document.createElement('div');
-        namePreview.className = 'name-preview';
+        const nameText = document.createElement('span');
+        nameText.className = 'name-text';
+        nameText.textContent = suggestion;
 
-        const nameHeading = document.createElement('h2');
-        nameHeading.textContent = suggestion;
-
-        const nameType = document.createElement('span');
-        nameType.className = 'name-type';
-        nameType.textContent = isAccepted ? 'Selected identity' : 'Suggested identity';
-
-        namePreview.appendChild(nameHeading);
-        namePreview.appendChild(nameType);
-
-        currentDisplay.appendChild(avatarPreview);
-        currentDisplay.appendChild(namePreview);
+        preview.appendChild(avatarPreview);
+        preview.appendChild(nameText);
 
         const actions = document.createElement('div');
         actions.className = 'name-actions';
 
         const acceptButton = document.createElement('button');
         acceptButton.type = 'button';
-        acceptButton.className = 'btn btn-primary';
-        const acceptIcon = document.createElement('span');
-        acceptIcon.textContent = '✓';
-        const acceptText = document.createElement('span');
-        acceptText.textContent = isAccepted ? 'Selected' : 'I like this one';
-        acceptButton.appendChild(acceptIcon);
-        acceptButton.appendChild(acceptText);
+        acceptButton.className = 'btn-primary';
+        acceptButton.textContent = isAccepted ? 'Selected' : 'Use this name';
         if (isAccepted) {
           acceptButton.disabled = true;
           acceptButton.setAttribute('aria-disabled', 'true');
@@ -1667,47 +1757,14 @@ class SecureChat {
 
         const regenerateButton = document.createElement('button');
         regenerateButton.type = 'button';
-        regenerateButton.className = 'btn btn-secondary';
-        const regenerateIcon = document.createElement('span');
-        regenerateIcon.textContent = '🎲';
-        const regenerateText = document.createElement('span');
-        regenerateText.textContent = 'Try another';
-        regenerateButton.appendChild(regenerateIcon);
-        regenerateButton.appendChild(regenerateText);
+        regenerateButton.className = 'btn-secondary';
+        regenerateButton.textContent = 'Try another';
         regenerateButton.addEventListener('click', () => this.tryAnotherIdentitySuggestion());
-
-        const customButton = document.createElement('button');
-        customButton.type = 'button';
-        customButton.className = 'btn-text';
-        customButton.textContent = 'or create custom name';
-        customButton.addEventListener('click', () => this.focusCustomIdentityInput());
 
         actions.appendChild(acceptButton);
         actions.appendChild(regenerateButton);
-        actions.appendChild(customButton);
-
-        const history = document.createElement('div');
-        history.className = 'rejected-names';
-        if (!rejected.length) {
-          history.hidden = true;
-        } else {
-          rejected.forEach((name) => {
-            if (typeof name !== 'string' || !name) {
-              return;
-            }
-            const pill = document.createElement('button');
-            pill.type = 'button';
-            pill.className = 'rejected-pill';
-            pill.textContent = name;
-            pill.setAttribute('aria-label', `Select ${name}`);
-            pill.addEventListener('click', () => this.selectPreviousIdentitySuggestion(name));
-            history.appendChild(pill);
-          });
-        }
-
-        card.appendChild(currentDisplay);
+        card.appendChild(preview);
         card.appendChild(actions);
-        card.appendChild(history);
 
         container.appendChild(card);
       }
@@ -1722,7 +1779,7 @@ class SecureChat {
         }
         if (this.identitySelectedName) {
           this.identitySelectedName = '';
-          this.updateJoinButtonText();
+          this.updateIdentityState();
         }
         this.clearIdentityError();
         this.renderIdentitySelector();
@@ -1734,9 +1791,10 @@ class SecureChat {
           return;
         }
         this.identitySelectedName = suggestion;
-        this.updateJoinButtonText();
+        this.updateIdentityState();
         this.clearIdentityError();
         this.renderIdentitySelector();
+        setTimeout(() => DOM.identityPasswordInput?.focus(), 0);
       }
 
       tryAnotherIdentitySuggestion(options = {}) {
@@ -1762,25 +1820,41 @@ class SecureChat {
         }
 
         this.renderIdentitySelector();
-        this.updateJoinButtonText();
+        this.updateIdentityState();
         this.clearIdentityError();
       }
 
-      selectPreviousIdentitySuggestion(name) {
-        if (typeof name !== 'string' || !name) {
+      async showReturningIdentityFromCreate() {
+        this.clearIdentityError();
+
+        if (!this.roomId) {
+          this.showIdentityError('Join a room before unlocking a saved identity.');
           return;
         }
 
-        this.identityRejectedNames = this.identityRejectedNames.filter((item) => item !== name);
-        this.identityCurrentSuggestion = name;
-
-        if (this.identitySelectedName !== name) {
-          this.identitySelectedName = '';
-          this.updateJoinButtonText();
+        if (!this.identityManager || this.identityManager.roomId !== this.roomId) {
+          try {
+            this.identityManager = new RoomIdentity(this.roomId);
+          } catch (error) {
+            console.warn('Unable to initialise identity manager for returning flow.', error);
+            this.showIdentityError('Identity service unavailable in this browser.');
+            return;
+          }
         }
 
-        this.clearIdentityError();
-        this.renderIdentitySelector();
+        try {
+          const stored = await this.identityManager.storage.getRoomIdentity(this.roomId);
+          if (stored) {
+            this.displayIdentityMode('returning', stored);
+            this.identityModalMode = 'returning';
+            setTimeout(() => DOM.identityReturningPassword?.focus(), 0);
+          } else {
+            this.showIdentityError('No saved identity found on this device yet.');
+          }
+        } catch (error) {
+          console.warn('Unable to load stored identity for returning flow.', error);
+          this.showIdentityError('Unable to load saved identity for this room.');
+        }
       }
 
       generateUniqueIdentitySuggestion() {
@@ -1828,13 +1902,25 @@ class SecureChat {
         if (/\d/.test(value)) score += 1;
         if (/[^A-Za-z0-9]/.test(value)) score += 1;
         score = Math.min(score, 4);
-        if (bar) {
-          bar.setAttribute('data-strength', String(score));
+        if (!bar || !text) {
+          return;
         }
-        if (text) {
-          const labels = ['Very weak', 'Weak', 'Okay', 'Strong', 'Excellent'];
-          text.textContent = labels[score] || 'Choose a strong password';
+
+        if (!value) {
+          bar.classList.add('hidden');
+          bar.style.setProperty('--strength', '0%');
+          text.classList.add('hidden');
+          text.textContent = 'Choose a strong password';
+          return;
         }
+
+        const percents = [0, 25, 50, 75, 100];
+        const labels = ['Very weak', 'Weak', 'Okay', 'Strong', 'Excellent'];
+
+        bar.classList.remove('hidden');
+        text.classList.remove('hidden');
+        bar.style.setProperty('--strength', `${percents[score] ?? 0}%`);
+        text.textContent = labels[score] || 'Choose a strong password';
       }
 
       showIdentityError(message) {
@@ -1867,6 +1953,7 @@ class SecureChat {
         if (mode === 'create') {
           this.refreshIdentitySuggestions(!this.identitySelectedName);
           this.updatePasswordStrength();
+          this.updateIdentityState();
           setTimeout(() => DOM.identityNameInput?.focus(), 0);
         } else {
           setTimeout(() => DOM.identityReturningPassword?.focus(), 0);
@@ -1881,34 +1968,59 @@ class SecureChat {
         const createSection = DOM.identityModeCreate;
         const returningSection = DOM.identityModeReturning;
         const title = DOM.identityModalTitle;
-        const hint = DOM.identityHint;
         const subtitle = DOM.identityModalSubtitle;
+        const returningTitle = DOM.identityReturningTitle;
+        const returningSubtitle = DOM.identityReturningSubtitle;
+        const returningName = DOM.identityReturningName;
+        const returningAvatar = DOM.identityReturningAvatar;
+        const returningLastSeen = DOM.identityReturningLastSeen;
         this.clearIdentityError();
 
         if (mode === 'returning') {
           createSection?.setAttribute('hidden', '');
           returningSection?.removeAttribute('hidden');
-          if (title) {
-            title.textContent = 'Welcome Back';
+          const preview = stored?.preview || {};
+          if (returningTitle) {
+            returningTitle.textContent = 'Welcome Back!';
           }
-          if (subtitle) {
-            subtitle.textContent = 'Unlock your saved identity to continue';
+          if (returningSubtitle) {
+            returningSubtitle.textContent = 'We found your previous identity';
           }
-          if (hint) {
-            hint.textContent = stored?.hint || 'You';
+          if (returningName) {
+            returningName.textContent = preview.displayName || stored?.hint || 'Saved identity';
+          }
+          if (returningAvatar) {
+            const emoji = preview?.avatar?.emoji || '🙂';
+            returningAvatar.textContent = emoji;
+            if (preview?.avatar?.color) {
+              returningAvatar.style.background = preview.avatar.color;
+              returningAvatar.style.color = '#fff';
+            } else {
+              returningAvatar.style.background = '';
+              returningAvatar.style.color = '';
+            }
+          }
+          if (returningLastSeen) {
+            if (preview?.lastSeen) {
+              returningLastSeen.hidden = false;
+              returningLastSeen.textContent = `Last here ${this.formatRelativeTime(preview.lastSeen)}`;
+            } else {
+              returningLastSeen.hidden = true;
+              returningLastSeen.textContent = '';
+            }
           }
           this.pendingStoredIdentity = stored || null;
         } else {
           returningSection?.setAttribute('hidden', '');
           createSection?.removeAttribute('hidden');
           if (title) {
-            title.textContent = 'Choose Your Identity';
+            title.textContent = 'Join Room';
           }
           if (subtitle) {
-            subtitle.textContent = 'Secure your seat in this room';
+            subtitle.textContent = 'Create your identity for this room';
           }
           this.pendingStoredIdentity = null;
-          this.updateJoinButtonText();
+          this.updateIdentityState();
         }
       }
 

--- a/index.html
+++ b/index.html
@@ -229,51 +229,102 @@
 
       <div id="identityModal" class="identity-modal" role="dialog" aria-modal="true" aria-labelledby="identityModalTitle" hidden>
         <div class="identity-dialog">
-          <div class="identity-header">
-            <h3 id="identityModalTitle">Choose Your Identity</h3>
-            <p id="identityModalSubtitle">Secure your seat in this room</p>
-          </div>
-
           <div id="identityModeCreate" class="identity-section">
-            <form id="identityCreateForm" novalidate>
-              <div class="identity-block">
-                <h4>Display Name</h4>
-                <p class="help-text">Pick a generated name or create your own</p>
-                <div id="identitySuggestions" class="name-suggestions"></div>
-                <div class="custom-name-option">
-                  <input type="text" id="identityNameInput" maxlength="30" placeholder="Or type your own…" autocomplete="off">
-                  <button type="button" id="identityRefreshBtn" class="refresh-btn">🎲 New suggestions</button>
+            <form id="identityCreateForm" class="identity-setup" novalidate>
+              <div class="setup-card">
+                <div class="card-header">
+                  <h1 id="identityModalTitle">Join Room</h1>
+                  <p id="identityModalSubtitle">Create your identity for this room</p>
                 </div>
-              </div>
 
-              <div class="identity-block">
-                <h4>Password</h4>
-                <p class="help-text">Create a password to rejoin this room later</p>
-                <div class="password-input-group">
-                  <input type="password" id="identityPasswordInput" placeholder="Create room password" autocomplete="new-password" required>
-                  <div class="password-strength">
-                    <div id="identityStrengthBar" class="strength-bar" data-strength="0"></div>
-                    <span id="identityStrengthText" class="strength-text">Choose a strong password</span>
+                <div class="setup-step active" id="identityStepName">
+                  <label class="step-label" for="identityNameInput">
+                    <span class="step-number">1</span>
+                    Choose your display name
+                  </label>
+                  <div class="name-selector">
+                    <div id="identitySuggestions" class="name-suggestions"></div>
+                    <details class="custom-name-section" id="identityCustomSection">
+                      <summary>Prefer a custom name?</summary>
+                      <input
+                        type="text"
+                        id="identityNameInput"
+                        maxlength="30"
+                        placeholder="Enter your own name"
+                        autocomplete="off"
+                      />
+                    </details>
                   </div>
                 </div>
-              </div>
 
-              <div class="identity-actions">
-                <button type="submit" class="btn btn-primary" id="identitySubmitBtn">Join Secure Room</button>
+                <div class="setup-step" id="identityStepPassword">
+                  <label class="step-label" for="identityPasswordInput">
+                    <span class="step-number">2</span>
+                    Secure your identity
+                  </label>
+                  <div class="password-section disabled" id="identityPasswordSection">
+                    <p class="help-text">This password lets you rejoin as the same person</p>
+                    <div class="password-input-wrapper">
+                      <input
+                        type="password"
+                        id="identityPasswordInput"
+                        placeholder="Create a password"
+                        autocomplete="new-password"
+                        disabled
+                        required
+                      />
+                    </div>
+                    <div class="password-strength hidden" id="identityStrengthBar"></div>
+                    <span class="strength-text hidden" id="identityStrengthText">Choose a strong password</span>
+                  </div>
+                </div>
+
+                <button type="submit" class="btn-primary large" id="identitySubmitBtn" disabled>
+                  Continue to Room
+                </button>
+
+                <div class="alternate-action">
+                  <button type="button" class="link-button" id="identityShowReturning">
+                    Already joined this room before?
+                  </button>
+                </div>
               </div>
             </form>
           </div>
 
           <div id="identityModeReturning" class="identity-section" hidden>
-            <form id="identityReturningForm" novalidate>
-              <div class="identity-block">
-                <h4>Welcome Back</h4>
-                <p class="help-text">Enter your password to rejoin as <strong id="identityHint">You</strong></p>
-                <input type="password" id="identityReturningPassword" placeholder="Enter your room password" autocomplete="current-password" required>
-              </div>
-              <div class="identity-actions">
-                <button type="submit" class="btn btn-primary">Rejoin Room</button>
-                <button type="button" class="btn btn-secondary" id="identityUseNew">Join as someone new</button>
+            <form id="identityReturningForm" class="identity-unlock" novalidate>
+              <div class="unlock-card">
+                <div class="card-header">
+                  <h1 id="identityReturningTitle">Welcome Back!</h1>
+                  <p id="identityReturningSubtitle">We found your previous identity</p>
+                </div>
+
+                <div class="identity-preview" aria-live="polite">
+                  <div class="avatar-large" id="identityReturningAvatar">🙂</div>
+                  <h2 id="identityReturningName">Saved identity</h2>
+                  <p class="last-seen" id="identityReturningLastSeen" hidden></p>
+                </div>
+
+                <div class="unlock-form">
+                  <label for="identityReturningPassword">Enter your password to continue</label>
+                  <input
+                    type="password"
+                    id="identityReturningPassword"
+                    placeholder="Your password"
+                    autocomplete="current-password"
+                    required
+                  />
+                  <button type="submit" class="btn-primary large" id="identityReturningSubmitBtn">
+                    Rejoin Room
+                  </button>
+                </div>
+
+                <div class="alternate-actions">
+                  <button type="button" class="link-button" id="identityJoinNew">Join as someone new</button>
+                  <span class="separator" aria-hidden="true">•</span>
+                  <button type="button" class="link-button" id="identityForgotPassword">Forgot password?</button>
+                </div>
               </div>
             </form>
           </div>
@@ -290,7 +341,7 @@
   <script src="https://unpkg.com/peerjs@1.5.1/dist/peerjs.min.js"></script>
 
   <script src="lib/identity.js"></script>
-    <script src="lib/events.js"></script>
+  <script src="lib/events.js"></script>
   <script src="lib/state.js"></script>
   <script src="lib/storage.js"></script>
   <script src="lib/crypto.js"></script>

--- a/lib/identity.js
+++ b/lib/identity.js
@@ -154,7 +154,12 @@ class RoomIdentity {
     await this.storage.saveRoomIdentity(this.roomId, {
       encrypted: encryptedIdentity,
       salt: this.toBase64(salt),
-      hint: `${displayName.slice(0, 3)}***`
+      hint: `${displayName.slice(0, 3)}***`,
+      preview: {
+        displayName,
+        avatar: identity.avatar,
+        lastSeen: identity.lastSeen
+      }
     });
 
     return identity;
@@ -180,6 +185,20 @@ class RoomIdentity {
 
     const identity = await this.decrypt(stored.encrypted, roomKey);
     identity.lastSeen = Date.now();
+
+    try {
+      await this.storage.saveRoomIdentity(this.roomId, {
+        ...stored,
+        preview: {
+          displayName: identity.displayName,
+          avatar: identity.avatar,
+          lastSeen: identity.lastSeen
+        }
+      });
+    } catch (error) {
+      console.warn('Unable to refresh identity preview metadata.', error);
+    }
+
     return identity;
   }
 

--- a/styles.css
+++ b/styles.css
@@ -1635,16 +1635,17 @@
       font-size: 0.85rem;
     }
 
+
     .identity-modal {
       position: fixed;
       inset: 0;
-      background: rgba(0, 0, 0, 0.75);
-      backdrop-filter: blur(12px);
-      -webkit-backdrop-filter: blur(12px);
+      background: rgba(15, 23, 42, 0.6);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
       display: flex;
       align-items: center;
       justify-content: center;
-      padding: 2rem;
+      padding: 1.5rem;
       z-index: 2000;
     }
 
@@ -1653,76 +1654,121 @@
     }
 
     .identity-dialog {
-      background: #101114;
-      border: 1px solid rgba(255, 255, 255, 0.06);
-      border-radius: 16px;
       width: min(520px, 100%);
-      padding: 2rem;
-      color: #fff;
-      box-shadow: 0 24px 60px rgba(0, 0, 0, 0.4);
-    }
-
-    .identity-header {
-      margin-bottom: 1.5rem;
-    }
-
-    .identity-header h3 {
-      margin: 0;
-      font-size: 1.5rem;
-    }
-
-    .identity-header p {
-      margin: 0.5rem 0 0;
-      color: #9da3b0;
-      font-size: 0.95rem;
+      border-radius: 20px;
+      background: #f1f5f9;
+      padding: 1.5rem;
+      box-shadow: 0 30px 80px rgba(15, 23, 42, 0.25);
     }
 
     .identity-section {
-      display: flex;
-      flex-direction: column;
-      gap: 1.5rem;
+      display: block;
     }
 
-    .identity-block {
+    .identity-setup {
+      margin: 0;
+    }
+
+    .setup-card {
+      background: #fff;
+      border-radius: 18px;
+      padding: 2rem;
+      box-shadow: 0 18px 50px rgba(15, 23, 42, 0.12);
+    }
+
+    .card-header {
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+
+    .card-header h1 {
+      margin: 0;
+      font-size: 1.65rem;
+      color: #0f172a;
+    }
+
+    .card-header p {
+      margin: 0.35rem 0 0;
+      color: #475569;
+      font-size: 0.95rem;
+    }
+
+    .setup-step {
+      border: 2px solid #e2e8f0;
+      border-radius: 14px;
+      padding: 1.25rem;
+      margin-bottom: 1.5rem;
+      transition: border 0.3s ease, background 0.3s ease, box-shadow 0.3s ease;
+    }
+
+    .setup-step.active {
+      border-color: #3b82f6;
+      background: #f0f9ff;
+      box-shadow: 0 10px 30px rgba(59, 130, 246, 0.15);
+    }
+
+    .setup-step.completed {
+      border-color: #22c55e;
+    }
+
+    .step-label {
       display: flex;
-      flex-direction: column;
+      align-items: center;
       gap: 0.75rem;
+      font-weight: 600;
+      color: #0f172a;
+      margin-bottom: 1rem;
     }
 
-    .identity-block h4 {
-      margin: 0;
-      font-size: 1rem;
+    .step-number {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 26px;
+      height: 26px;
+      border-radius: 999px;
+      background: #e2e8f0;
+      color: #1e293b;
+      font-size: 0.85rem;
+      font-weight: 700;
     }
 
-    .identity-block .help-text {
-      margin: 0;
-      color: #9da3b0;
-      font-size: 0.9rem;
+    .setup-step.active .step-number {
+      background: #3b82f6;
+      color: #fff;
     }
 
-    .name-suggestions {
+    .setup-step.completed .step-number {
+      background: #22c55e;
+      color: #fff;
+    }
+
+    .name-selector {
       display: flex;
       flex-direction: column;
       gap: 1rem;
     }
 
-    .name-selector-card {
-      background: rgba(255, 255, 255, 0.04);
-      border: 1px solid rgba(255, 255, 255, 0.08);
-      border-radius: 16px;
+    .name-suggestions {
+      width: 100%;
+    }
+
+    .suggested-name-card {
+      background: #f8fafc;
+      border-radius: 14px;
       padding: 1.25rem;
+      border: 1px solid #e2e8f0;
       display: flex;
       flex-direction: column;
       gap: 1.25rem;
-      transition: border 0.2s ease, box-shadow 0.2s ease;
     }
 
-    .name-selector-card[data-state='selected'] {
-      border-color: var(--accent);
-      box-shadow: 0 0 0 1px rgba(0, 102, 255, 0.3);
+    .suggested-name-card[data-state='selected'] {
+      border-color: #22c55e;
+      box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.15);
     }
 
-    .current-name-display {
+    .name-preview {
       display: flex;
       align-items: center;
       gap: 1rem;
@@ -1735,236 +1781,296 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 1.75rem;
-      color: rgba(0, 0, 0, 0.8);
-      background: rgba(255, 255, 255, 0.08);
+      font-size: 2rem;
+      color: #fff;
+      background: linear-gradient(135deg, #fbbf24, #f59e0b);
     }
 
-    .name-preview h2 {
-      margin: 0;
-      color: var(--text-primary);
+    .name-text {
       font-size: 1.25rem;
-      letter-spacing: 0.01em;
-    }
-
-    .name-preview .name-type {
-      display: inline-block;
-      margin-top: 0.15rem;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      font-size: 0.75rem;
-      color: var(--text-secondary);
+      font-weight: 600;
+      color: #0f172a;
     }
 
     .name-actions {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-    }
-
-    .name-actions .btn {
-      flex: 1 1 160px;
-      justify-content: center;
-    }
-
-    .name-actions .btn-text {
-      flex: 0 0 auto;
-      align-self: center;
-    }
-
-    .btn-text {
-      background: none;
-      border: none;
-      color: var(--text-secondary);
-      font-size: 0.95rem;
-      font-weight: 500;
-      cursor: pointer;
-      text-decoration: underline;
-      padding: 0.25rem 0.5rem;
-      transition: color 0.2s ease;
-    }
-
-    .btn-text:hover,
-    .btn-text:focus-visible {
-      color: var(--accent);
-      outline: none;
-    }
-
-    .rejected-names {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-    }
-
-    .rejected-pill {
-      background: rgba(255, 255, 255, 0.05);
-      border: 1px solid rgba(255, 255, 255, 0.08);
-      color: var(--text-secondary);
-      border-radius: 999px;
-      padding: 0.35rem 0.75rem;
-      font-size: 0.85rem;
-      cursor: pointer;
-      transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-    }
-
-    .rejected-pill:hover,
-    .rejected-pill:focus-visible {
-      background: rgba(255, 255, 255, 0.12);
-      border-color: var(--accent);
-      color: var(--text-primary);
-      outline: none;
-    }
-
-    .custom-name-option {
-      display: flex;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
       gap: 0.75rem;
-      align-items: center;
     }
 
-    .custom-name-option input {
-      flex: 1;
-      padding: 0.75rem 1rem;
-      border-radius: 10px;
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      background: rgba(255, 255, 255, 0.05);
-      color: #fff;
+    .name-actions button {
+      border: none;
+      border-radius: 12px;
+      padding: 0.85rem 1.1rem;
+      font-weight: 600;
       font-size: 0.95rem;
-    }
-
-    .custom-name-option input::placeholder {
-      color: rgba(255, 255, 255, 0.5);
-    }
-
-    .refresh-btn {
-      background: rgba(255, 255, 255, 0.08);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      border-radius: 8px;
-      padding: 0.75rem 1rem;
-      color: #fff;
       cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .name-actions .btn-primary {
+      background: #3b82f6;
+      color: #fff;
+      box-shadow: 0 12px 24px rgba(59, 130, 246, 0.25);
+    }
+
+    .name-actions .btn-primary:hover {
+      transform: translateY(-1px);
+    }
+
+    .name-actions .btn-secondary {
+      background: #e2e8f0;
+      color: #1e293b;
+    }
+
+    .name-actions .btn-secondary:hover {
+      transform: translateY(-1px);
+    }
+
+    .custom-name-section {
+      background: #f8fafc;
+      border-radius: 12px;
+      padding: 0.85rem 1rem;
+      border: 1px solid #e2e8f0;
       font-size: 0.9rem;
-      transition: background 0.2s ease;
+      color: #2563eb;
     }
 
-    .refresh-btn:hover {
-      background: rgba(255, 255, 255, 0.12);
+    .custom-name-section summary {
+      cursor: pointer;
+      font-weight: 600;
+      outline: none;
+      list-style: none;
     }
 
-    .password-input-group {
+    .custom-name-section summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .custom-name-section[open] summary {
+      margin-bottom: 0.75rem;
+    }
+
+    .custom-name-section input {
+      width: 100%;
+      border: 1px solid #cbd5f5;
+      border-radius: 10px;
+      padding: 0.75rem 0.9rem;
+      font-size: 0.95rem;
+      outline: none;
+      color: #0f172a;
+      background: #fff;
+    }
+
+    .custom-name-section input:focus {
+      border-color: #3b82f6;
+      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+    }
+
+    .password-section {
       display: flex;
       flex-direction: column;
       gap: 0.75rem;
+      transition: opacity 0.3s ease;
     }
 
-    .password-input-group input {
-      padding: 0.9rem 1rem;
+    .password-section.disabled {
+      opacity: 0.5;
+      pointer-events: none;
+    }
+
+    .password-input-wrapper {
+      position: relative;
+    }
+
+    .password-input-wrapper input {
+      width: 100%;
+      border: 1px solid #cbd5f5;
       border-radius: 10px;
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      background: rgba(255, 255, 255, 0.05);
-      color: #fff;
+      padding: 0.85rem 1rem;
+      font-size: 1rem;
+      outline: none;
+      color: #0f172a;
+      background: #fff;
+      transition: border 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .password-input-wrapper input:focus {
+      border-color: #3b82f6;
+      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
     }
 
     .password-strength {
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-    }
-
-    .strength-bar {
+      width: 100%;
       height: 6px;
-      flex: 1;
-      background: rgba(255, 255, 255, 0.1);
-      border-radius: 4px;
-      position: relative;
+      border-radius: 999px;
+      background: #e2e8f0;
       overflow: hidden;
+      position: relative;
     }
 
-    .strength-bar::after {
+    .password-strength::after {
       content: '';
       position: absolute;
       inset: 0;
-      transform-origin: left;
-      transform: scaleX(0.15);
-      background: #f87171;
-      transition: transform 0.3s ease, background 0.3s ease;
+      background: linear-gradient(90deg, #ef4444, #f59e0b, #22c55e);
+      width: var(--strength, 0%);
+      transition: width 0.3s ease;
     }
 
-    .strength-bar[data-strength="1"]::after {
-      transform: scaleX(0.3);
-      background: #f87171;
-    }
-
-    .strength-bar[data-strength="2"]::after {
-      transform: scaleX(0.6);
-      background: #fbbf24;
-    }
-
-    .strength-bar[data-strength="3"]::after {
-      transform: scaleX(0.85);
-      background: #34d399;
-    }
-
-    .strength-bar[data-strength="4"]::after {
-      transform: scaleX(1);
-      background: #22c55e;
+    .password-strength.hidden {
+      display: none;
     }
 
     .strength-text {
-      color: #9da3b0;
       font-size: 0.85rem;
+      color: #475569;
     }
 
-    .identity-actions {
+    .strength-text.hidden {
+      display: none;
+    }
+
+    .btn-primary.large {
+      width: 100%;
+      border: none;
+      border-radius: 12px;
+      padding: 0.95rem 1.25rem;
+      font-size: 1rem;
+      font-weight: 600;
+      background: linear-gradient(135deg, #2563eb, #1d4ed8);
+      color: #fff;
+      cursor: pointer;
+      box-shadow: 0 18px 35px rgba(37, 99, 235, 0.2);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .btn-primary.large:disabled {
+      background: #bfdbfe;
+      color: #1e3a8a;
+      cursor: not-allowed;
+      box-shadow: none;
+    }
+
+    .btn-primary.large:not(:disabled):hover {
+      transform: translateY(-1px);
+    }
+
+    .alternate-action {
+      text-align: center;
+      margin-top: 1.5rem;
+      padding-top: 1.25rem;
+      border-top: 1px solid #e2e8f0;
+    }
+
+    .link-button {
+      background: none;
+      border: none;
+      padding: 0;
+      color: #2563eb;
+      font-weight: 600;
+      font-size: 0.95rem;
+      cursor: pointer;
+    }
+
+    .link-button:hover,
+    .link-button:focus {
+      text-decoration: underline;
+    }
+
+    .identity-unlock .card-header h1 {
+      color: #0f172a;
+    }
+
+    .unlock-card {
+      background: #fff;
+      border-radius: 18px;
+      padding: 2rem;
+      box-shadow: 0 18px 50px rgba(15, 23, 42, 0.12);
+    }
+
+    .identity-preview {
+      text-align: center;
+      padding: 1.5rem;
+      background: #f8fafc;
+      border-radius: 14px;
+      margin-bottom: 1.75rem;
+    }
+
+    .avatar-large {
+      width: 86px;
+      height: 86px;
+      margin: 0 auto 1rem;
+      border-radius: 18px;
       display: flex;
-      gap: 0.75rem;
       align-items: center;
+      justify-content: center;
+      font-size: 2.5rem;
+      background: linear-gradient(135deg, #6366f1, #8b5cf6);
+      color: #fff;
     }
 
-    .identity-error {
-      margin-top: 1rem;
-      padding: 0.75rem 1rem;
+    .identity-preview h2 {
+      margin: 0;
+      font-size: 1.35rem;
+      color: #0f172a;
+    }
+
+    .last-seen {
+      margin-top: 0.35rem;
+      font-size: 0.85rem;
+      color: #64748b;
+    }
+
+    .unlock-form {
+      display: flex;
+      flex-direction: column;
+      gap: 0.85rem;
+    }
+
+    .unlock-form label {
+      font-weight: 600;
+      color: #0f172a;
+    }
+
+    .unlock-form input {
+      border: 1px solid #cbd5f5;
       border-radius: 10px;
-      background: rgba(248, 113, 113, 0.12);
-      border: 1px solid rgba(248, 113, 113, 0.4);
-      color: #fecaca;
+      padding: 0.85rem 1rem;
+      font-size: 1rem;
+      outline: none;
+      transition: border 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .unlock-form input:focus {
+      border-color: #3b82f6;
+      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+    }
+
+    .alternate-actions {
+      margin-top: 1.25rem;
+      text-align: center;
+      color: #94a3b8;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
       font-size: 0.9rem;
     }
 
-    .identity-setup-flow {
-      max-width: 400px;
-      margin: 0 auto;
+    .alternate-actions .separator {
+      color: #cbd5f5;
     }
 
-    .password-strength-meter {
-      margin: 1rem 0;
-      background: #f1f5f9;
-      height: 8px;
-      border-radius: 4px;
-      overflow: hidden;
-    }
-
-    .strength-fill {
-      height: 100%;
-      transition: all 0.3s;
-      background: linear-gradient(90deg, #ef4444 0%, #f59e0b 33%, #eab308 66%, #22c55e 100%);
-      width: var(--strength, 0%);
-    }
-
-    .requirement {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      padding: 0.25rem 0;
-      color: #64748b;
-      transition: color 0.2s ease;
-    }
-
-    .requirement[data-met="true"] {
-      color: #22c55e;
-    }
-
-    .requirement[data-met="true"] .check {
-      color: #22c55e;
+    .identity-error {
+      margin-top: 1.5rem;
+      padding: 0.85rem 1rem;
+      border-radius: 12px;
+      background: rgba(248, 113, 113, 0.12);
+      border: 1px solid rgba(248, 113, 113, 0.35);
+      color: #b91c1c;
+      font-size: 0.9rem;
+      text-align: center;
     }
 
     .seats-grid {


### PR DESCRIPTION
## Summary
- redesign the identity modal into a progressive name then password flow with a dedicated returning-user unlock view
- restyle the modal for clearer hierarchy and focused actions while wiring step state updates and return detection in the app logic
- persist identity preview metadata so returning users can see their saved avatar and name hints before unlocking

## Testing
- node tests/crypto.spec.js
- node tests/replay.js
- node tests/fuzz.js

------
https://chatgpt.com/codex/tasks/task_b_68d4a8d50fcc833280ab32cccbaabf5d