### PR TITLE
Restyle right sidebar for dark theme

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1320,32 +1320,36 @@
     }
 
     .members-sidebar {
-      background: #ffffff;
-      border-left: 1px solid #e2e8f0;
+      background: #0a0a0a;
+      border-left: 1px solid #1a1a1a;
       display: flex;
       flex-direction: column;
       min-height: 0;
-      color: #0f172a;
+      color: #e0e0e0;
     }
 
     .members-sidebar-inner {
       display: flex;
       flex-direction: column;
       height: 100%;
-      background: #ffffff;
+      background: #0a0a0a;
     }
 
     .right-panel {
-      background: #ffffff;
+      background: #0a0a0a;
       display: flex;
       flex-direction: column;
       height: 100%;
     }
 
+    .members-sidebar * {
+      box-shadow: none !important;
+    }
+
     .panel-tabs {
       display: flex;
-      border-bottom: 1px solid #e2e8f0;
-      background: #f8fafc;
+      border-bottom: 1px solid #1a1a1a;
+      background: transparent;
     }
 
     .panel-tab {
@@ -1353,7 +1357,7 @@
       padding: 0.75rem;
       background: transparent;
       border: none;
-      color: #64748b;
+      color: #6b7280;
       font-size: 0.875rem;
       font-weight: 600;
       cursor: pointer;
@@ -1366,19 +1370,19 @@
     }
 
     .panel-tab:hover {
-      color: #1e293b;
-      background: rgba(59, 130, 246, 0.05);
+      color: #e0e0e0;
+      background: rgba(255, 255, 255, 0.05);
     }
 
     .panel-tab.active {
       color: #3b82f6;
       border-bottom-color: #3b82f6;
-      background: #ffffff;
+      background: transparent;
     }
 
     .panel-tab .tab-count {
-      background: #e2e8f0;
-      color: #475569;
+      background: rgba(255, 255, 255, 0.08);
+      color: #e0e0e0;
       padding: 0.125rem 0.5rem;
       border-radius: 999px;
       font-size: 0.75rem;
@@ -1388,7 +1392,7 @@
 
     .panel-tab.active .tab-count {
       background: #3b82f6;
-      color: #ffffff;
+      color: #000000;
     }
 
     .panel-content {
@@ -1396,7 +1400,7 @@
       padding: 1.25rem;
       height: 100%;
       overflow-y: auto;
-      background: #ffffff;
+      background: #0a0a0a;
     }
 
     .panel-content.active {
@@ -1415,31 +1419,37 @@
 
     .panel-search {
       padding: 0.75rem;
-      border-bottom: 1px solid #f1f5f9;
+      border-bottom: 1px solid #1a1a1a;
+      background: #0a0a0a;
     }
 
     .search-input {
       width: 100%;
       padding: 0.5rem 0.75rem;
-      background: #f8fafc;
-      border: 1px solid transparent;
+      background: #111111;
+      border: 1px solid #1a1a1a;
       border-radius: 8px;
       font-size: 0.875rem;
+      color: #e0e0e0;
       transition: all 0.2s ease;
+    }
+
+    .search-input::placeholder {
+      color: #6b7280;
     }
 
     .search-input:focus {
       outline: none;
-      background: #ffffff;
+      background: #0f0f0f;
       border-color: #3b82f6;
-      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12);
+      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
     }
 
     .members-panel {
       flex: 1;
       display: flex;
       flex-direction: column;
-      background: #ffffff;
+      background: #0a0a0a;
     }
 
     .member-section {
@@ -1455,12 +1465,12 @@
       display: flex;
       align-items: center;
       padding: 0.5rem 0.75rem;
-      background: #f8fafc;
-      border-bottom: 1px solid #f1f5f9;
+      background: rgba(255, 255, 255, 0.03);
+      border-bottom: none;
       font-size: 0.75rem;
       font-weight: 700;
       text-transform: uppercase;
-      color: #64748b;
+      color: #6b7280;
       letter-spacing: 0.05em;
       gap: 0.5rem;
     }
@@ -1468,14 +1478,14 @@
     .section-header.collapsible {
       cursor: pointer;
       border: none;
-      background: #f8fafc;
+      background: rgba(255, 255, 255, 0.03);
       width: 100%;
       text-align: left;
       transition: background 0.2s ease;
     }
 
     .section-header.collapsible:hover {
-      background: #f1f5f9;
+      background: rgba(255, 255, 255, 0.06);
     }
 
     .section-title {
@@ -1485,13 +1495,13 @@
 
     .section-arrow {
       font-size: 0.75rem;
-      color: #94a3b8;
+      color: #6b7280;
     }
 
     .section-count {
       margin-left: auto;
-      background: #e2e8f0;
-      color: #475569;
+      background: rgba(255, 255, 255, 0.06);
+      color: #e0e0e0;
       padding: 0.125rem 0.5rem;
       border-radius: 999px;
       font-size: 0.7rem;
@@ -1512,22 +1522,24 @@
       border-radius: 10px;
       transition: background 0.15s ease;
       cursor: pointer;
+      background: transparent;
+      color: #e0e0e0;
     }
 
     .member-item:hover {
-      background: #f8fafc;
+      background: rgba(255, 255, 255, 0.05);
     }
 
     .member-avatar {
       width: 2.25rem;
       height: 2.25rem;
       border-radius: 0.75rem;
-      background: linear-gradient(135deg, var(--color-1, #667eea), #764ba2);
+      background: #1a1a1a;
       display: flex;
       align-items: center;
       justify-content: center;
       font-size: 1rem;
-      color: #ffffff;
+      color: #e0e0e0;
       position: relative;
       flex-shrink: 0;
     }
@@ -1543,12 +1555,12 @@
       width: 0.625rem;
       height: 0.625rem;
       border-radius: 50%;
-      border: 2px solid #ffffff;
-      background: #22c55e;
+      border: 2px solid #0a0a0a;
+      background: #10b981;
     }
 
     .member-avatar.offline .status-dot {
-      background: #94a3b8;
+      background: #374151;
     }
 
     .member-details {
@@ -1564,7 +1576,7 @@
       align-items: center;
       gap: 0.5rem;
       font-weight: 600;
-      color: #1e293b;
+      color: #ffffff;
       font-size: 0.9rem;
       white-space: nowrap;
       overflow: hidden;
@@ -1572,8 +1584,8 @@
     }
 
     .host-badge {
-      background: linear-gradient(135deg, #fbbf24, #f59e0b);
-      color: #ffffff;
+      background: #d97706;
+      color: #000000;
       padding: 0.125rem 0.375rem;
       border-radius: 4px;
       font-size: 0.625rem;
@@ -1584,7 +1596,7 @@
 
     .member-role {
       font-size: 0.75rem;
-      color: #64748b;
+      color: #6b7280;
     }
 
     .typing-status {
@@ -1594,7 +1606,7 @@
     }
 
     .member-meta {
-      color: #94a3b8;
+      color: #6b7280;
       font-size: 0.75rem;
       display: flex;
       align-items: center;
@@ -1612,7 +1624,7 @@
       height: 1.5rem;
       border: none;
       background: transparent;
-      color: #94a3b8;
+      color: #6b7280;
       border-radius: 4px;
       display: flex;
       align-items: center;
@@ -1628,19 +1640,20 @@
     }
 
     .member-action:hover {
-      background: #e2e8f0;
-      color: #475569;
+      background: rgba(255, 255, 255, 0.05);
+      color: #e0e0e0;
     }
 
     .pending-invite {
       display: flex;
       align-items: center;
       gap: 1rem;
-      background: #f8fafc;
-      border: 1px solid #e2e8f0;
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid #1a1a1a;
       padding: 0.75rem;
       border-radius: 10px;
       margin: 0.75rem;
+      color: #e0e0e0;
     }
 
     .invite-icon {
@@ -1652,7 +1665,7 @@
       display: flex;
       flex-direction: column;
       gap: 0.25rem;
-      color: #475569;
+      color: #6b7280;
       font-size: 0.8rem;
     }
 
@@ -1664,7 +1677,7 @@
     .cancel-btn {
       border: none;
       background: #3b82f6;
-      color: #ffffff;
+      color: #000000;
       padding: 0.5rem 0.75rem;
       border-radius: 6px;
       cursor: pointer;
@@ -1674,6 +1687,7 @@
 
     .cancel-btn:hover {
       background: #2563eb;
+      color: #ffffff;
     }
 
     .room-actions {
@@ -1691,23 +1705,23 @@
       gap: 0.5rem;
       padding: 0.75rem;
       border-radius: 8px;
-      border: 1px solid #e2e8f0;
-      background: #ffffff;
-      color: #1e293b;
+      border: 1px solid #1a1a1a;
+      background: rgba(255, 255, 255, 0.03);
+      color: #e0e0e0;
       font-weight: 600;
       cursor: pointer;
       transition: all 0.2s ease;
     }
 
     .action-btn:hover {
-      background: #f8fafc;
-      border-color: #cbd5e1;
+      background: rgba(255, 255, 255, 0.05);
+      border-color: #2a2a2a;
     }
 
     .action-btn.danger {
-      color: #dc2626;
-      border-color: rgba(220, 38, 38, 0.2);
-      background: #fef2f2;
+      color: #f87171;
+      border-color: rgba(248, 113, 113, 0.2);
+      background: rgba(248, 113, 113, 0.08);
     }
 
     .chat-tab-placeholder {
@@ -1715,11 +1729,11 @@
       align-items: center;
       justify-content: center;
       min-height: 200px;
-      color: #64748b;
+      color: #6b7280;
       text-align: center;
-      background: #f8fafc;
+      background: rgba(255, 255, 255, 0.03);
       border-radius: 16px;
-      border: 1px dashed #cbd5f5;
+      border: 1px dashed #1f2937;
       padding: 2rem;
     }
 
@@ -1727,30 +1741,30 @@
       display: flex;
       flex-direction: column;
       gap: 1rem;
-      background: #ffffff;
+      background: #0a0a0a;
     }
 
     .info-card {
-      background: #f8fafc;
+      background: rgba(255, 255, 255, 0.03);
       border-radius: 12px;
       padding: 1rem;
       display: flex;
       flex-direction: column;
       gap: 0.5rem;
-      border: 1px solid #e2e8f0;
+      border: 1px solid #1a1a1a;
     }
 
     .info-title {
       font-size: 0.75rem;
       font-weight: 700;
       text-transform: uppercase;
-      color: #64748b;
+      color: #6b7280;
       letter-spacing: 0.05em;
     }
 
     .info-value {
       font-size: 0.9rem;
-      color: #1e293b;
+      color: #e0e0e0;
       font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
       word-break: break-word;
     }
@@ -1758,16 +1772,17 @@
     .empty-state {
       padding: 0.75rem;
       border-radius: 8px;
-      background: #f8fafc;
-      color: #94a3b8;
+      background: rgba(255, 255, 255, 0.03);
+      color: #6b7280;
       text-align: center;
       font-size: 0.8rem;
+      border: 1px dashed #1a1a1a;
     }
 
     .empty-state.subtle {
-      border: 1px dashed #e2e8f0;
-      background: #ffffff;
-      color: #94a3b8;
+      border: 1px dashed #1a1a1a;
+      background: transparent;
+      color: #6b7280;
     }
 
     .identity-modal {


### PR DESCRIPTION
## Summary
- align the members sidebar, tabs, and panels with the app's dark background palette
- soften text hierarchy, hover states, and badges to use muted grays with blue accents
- simplify cards, invites, and actions with translucent backgrounds and minimal borders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d4ab4735008332a04f57aed7d4721c