### PR TITLE
Route workspace hub separately from legacy chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,10 @@
               <span>🔗</span>
               <span>Join Room</span>
             </button>
+            <button class="btn btn-ghost" type="button" onclick="App.exitToWorkspace()">
+              <span>🏢</span>
+              <span>Workspaces</span>
+            </button>
           </div>
 
           <!-- Room History -->

--- a/styles.css
+++ b/styles.css
@@ -23,12 +23,17 @@
       --reorder-glow-duration: 2s;
     }
 
+    [hidden] {
+      display: none !important;
+    }
+
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
       background: var(--bg-primary);
       color: var(--text-primary);
       height: 100vh;
-      overflow: hidden;
+      overflow-x: hidden;
+      overflow-y: auto;
       display: flex;
       flex-direction: column;
       position: relative;
@@ -3001,6 +3006,7 @@
   display: flex;
   gap: 1rem;
   margin-top: 1.75rem;
+  flex-wrap: wrap;
 }
 
 .btn-primary.large,
@@ -3137,6 +3143,44 @@
   border: 1px solid #e2e8f0;
   padding: 2rem;
   box-shadow: 0 25px 50px -40px rgba(15, 23, 42, 0.45);
+}
+
+.quick-room-card {
+  margin-top: 2.5rem;
+  background: rgba(15, 23, 42, 0.92);
+  border-radius: 18px;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  padding: 2rem;
+  color: white;
+  box-shadow: 0 25px 50px -35px rgba(15, 23, 42, 0.75);
+}
+
+.quick-room-card h3 {
+  font-size: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.quick-room-card p {
+  color: rgba(226, 232, 240, 0.85);
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+}
+
+.quick-room-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.btn-ghost {
+  background: transparent;
+  color: rgba(226, 232, 240, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.btn-ghost:hover {
+  background: rgba(148, 163, 184, 0.12);
+  transform: translateY(-2px);
 }
 
 .workspace-dashboard-header {

--- a/workspace.js
+++ b/workspace.js
@@ -107,6 +107,7 @@ class WorkspaceApp {
       return;
     }
     this.updateHeroStats();
+    const quickCard = this.renderQuickRoomCard();
     if (!this.state.workspaces.length) {
       this.elements.content.innerHTML = `
         <div class="workspace-empty">
@@ -115,8 +116,10 @@ class WorkspaceApp {
           <p>Persistent hubs keep members, invites, and channels available even after everyone leaves.</p>
           <button class="btn-primary large" id="emptyCreateBtn">Start Workspace Setup</button>
         </div>
+        ${quickCard}
       `;
       document.getElementById('emptyCreateBtn')?.addEventListener('click', () => this.showCreation());
+      this.bindQuickRoomActions();
       return;
     }
 
@@ -158,7 +161,10 @@ class WorkspaceApp {
       `;
     }).join('');
 
-    this.elements.content.innerHTML = `<div class="workspace-grid">${cards}</div>`;
+    this.elements.content.innerHTML = `
+      <div class="workspace-grid">${cards}</div>
+      ${quickCard}
+    `;
     this.elements.content.querySelectorAll('[data-action="open"]').forEach(button => {
       button.addEventListener('click', event => {
         event.stopPropagation();
@@ -171,6 +177,37 @@ class WorkspaceApp {
         const id = card.getAttribute('data-id');
         this.openWorkspace(id);
       });
+    });
+    this.bindQuickRoomActions();
+  }
+
+  renderQuickRoomCard() {
+    return `
+      <section class="quick-room-card" aria-label="Quick secure room options">
+        <h3>Need a one-off secure room?</h3>
+        <p>Launch the classic Secure Chat experience for instant, end-to-end encrypted conversations.</p>
+        <div class="quick-room-actions">
+          <button class="btn btn-primary" id="quickRoomHost">Create Secure Room</button>
+          <button class="btn btn-secondary" id="quickRoomJoin">Join with Invite</button>
+          <button class="btn btn-ghost" id="quickRoomOpen">Open Secure Chat</button>
+        </div>
+      </section>
+    `;
+  }
+
+  bindQuickRoomActions() {
+    const hostBtn = this.elements.content?.querySelector('#quickRoomHost');
+    const joinBtn = this.elements.content?.querySelector('#quickRoomJoin');
+    const openBtn = this.elements.content?.querySelector('#quickRoomOpen');
+
+    hostBtn?.addEventListener('click', () => {
+      window.App?.enterLegacyMode?.({ mode: 'host' });
+    });
+    joinBtn?.addEventListener('click', () => {
+      window.App?.enterLegacyMode?.({ mode: 'join' });
+    });
+    openBtn?.addEventListener('click', () => {
+      window.App?.enterLegacyMode?.({ mode: 'welcome' });
     });
   }
 


### PR DESCRIPTION
## Summary
- add layout controls in the chat app to toggle between the new workspace hub and the legacy secure room UI
- expose quick actions in the workspace landing page plus a "Workspaces" return button so users can launch or leave the legacy experience
- update shared styles for the new quick-start card, ghost button, and layout/overflow handling

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_b_68d4acab541c8332816a8549863596ab