### PR TITLE
Fix workspace initialization and modal handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -2818,6 +2818,9 @@ This invite can be used only once. Share the link privately.`;
         this.setRoomContextMode(null);
         this.useWorkspaceLayout();
         this.roomURLManager.clearRoute();
+        if (!window.workspaceApp) {
+          window.workspaceApp = new WorkspaceApp();
+        }
         if (window.workspaceApp?.renderLanding) {
           window.workspaceApp.renderLanding();
         }

--- a/index.html
+++ b/index.html
@@ -309,7 +309,7 @@
         </select>
         <div class="modal-actions">
           <button type="submit" class="btn-primary">Create Workspace</button>
-          <button type="button" class="btn-secondary" onclick="closeModal('createWorkspaceModal')">Cancel</button>
+          <button type="button" class="btn-secondary" data-action="close-modal" data-target="createWorkspaceModal">Cancel</button>
         </div>
       </form>
     </div>
@@ -321,7 +321,7 @@
       <h2 id="findWorkspaceTitle">Find Workspaces</h2>
       <input type="text" id="workspaceSearch" placeholder="Search or enter invite code">
       <div id="workspaceList"></div>
-      <button class="btn-secondary" onclick="closeModal('findWorkspaceModal')">Close</button>
+      <button class="btn-secondary" data-action="close-modal" data-target="findWorkspaceModal">Close</button>
     </div>
   </div>
 

--- a/styles.css
+++ b/styles.css
@@ -4206,3 +4206,52 @@
   }
 }
 
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal-content {
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 24px;
+  max-width: 500px;
+  width: 90%;
+  max-height: 80vh;
+  overflow-y: auto;
+  color: #000;
+}
+
+.modal-error {
+  color: #d32f2f;
+  margin-bottom: 16px;
+  font-size: 14px;
+}
+
+.workspace-empty-result {
+  padding: 40px;
+  text-align: center;
+  color: #666;
+}
+
+.discovery-card {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 12px;
+  background: #fff;
+  color: #000;
+}
+

--- a/workspace.js
+++ b/workspace.js
@@ -163,6 +163,17 @@ function closeModal(id) {
   }
 }
 
+document.addEventListener('click', event => {
+  const button = event.target.closest('[data-action="close-modal"]');
+  if (!button) {
+    return;
+  }
+  const target = button.getAttribute('data-target');
+  if (target) {
+    closeModal(target);
+  }
+});
+
 function clearModal(form) {
   if (!form) {
     return;
@@ -754,20 +765,34 @@ class WorkspaceApp {
   }
 }
 
-// Initialize workspace functionality when DOM loads
-document.addEventListener('DOMContentLoaded', function() {
+function initializeWorkspace() {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeWorkspace, { once: true });
+    return;
+  }
+
+  window.closeModal = closeModal;
+
+  if (!window.workspaceApp) {
+    window.workspaceApp = new WorkspaceApp();
+  }
+
+  window.enterWorkspace = enterWorkspace;
+  window.leaveWorkspaceView = leaveWorkspaceView;
+
   const createBtn = document.getElementById('createWorkspaceBtn');
   const findBtn = document.getElementById('findWorkspaceBtn');
 
-  if (createBtn) {
+  if (createBtn && !createBtn._initialized) {
     createBtn.addEventListener('click', showCreateWorkspaceModal);
+    createBtn._initialized = true;
   }
 
-  if (findBtn) {
+  if (findBtn && !findBtn._initialized) {
     findBtn.addEventListener('click', showFindWorkspaceModal);
+    findBtn._initialized = true;
   }
 
-  // Update hero stats on load
   updateWorkspaceStats();
 
   const activeRaw = localStorage.getItem(ACTIVE_WORKSPACE_KEY);
@@ -781,7 +806,9 @@ document.addEventListener('DOMContentLoaded', function() {
       console.warn('Unable to restore active workspace', error);
     }
   }
-});
+}
+
+initializeWorkspace();
 
 function updateWorkspaceStats() {
   const statsEl = document.getElementById('workspaceHeroStats');
@@ -806,8 +833,3 @@ window.addEventListener('keydown', event => {
   }
 });
 
-window.closeModal = closeModal;
-window.enterWorkspace = enterWorkspace;
-window.leaveWorkspaceView = leaveWorkspaceView;
-
-window.workspaceApp = new WorkspaceApp();


### PR DESCRIPTION
## Summary
- delay workspace bootstrapping until the DOM is ready and expose helpers after setup
- add delegated modal close handling and instantiate the workspace app when exiting legacy mode
- provide base modal and discovery styles required by the workspace UI

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d585379d3c8332849b6f4900b09bf7