### PR TITLE
Improve initial workspace landing choice

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3057,6 +3057,20 @@
   font-size: 3rem;
 }
 
+.workspace-empty__actions {
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 600px) {
+  .workspace-empty__actions {
+    flex-direction: row;
+    justify-content: center;
+  }
+}
+
 .workspace-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));

--- a/workspace.js
+++ b/workspace.js
@@ -704,12 +704,20 @@ class WorkspaceApp {
       this.content.innerHTML = `
         <div class="workspace-empty">
           <div class="empty-illustration">✨</div>
-          <h2>Create your first workspace</h2>
-          <p>Persistent hubs keep members, invites, and channels available even after everyone leaves.</p>
-          <button class="btn-primary large" id="startWorkspaceBtn">Start Workspace Setup</button>
+          <h2>How would you like to get started?</h2>
+          <p>Would you like to create a new workspace or join an existing one?</p>
+          <div class="workspace-empty__actions">
+            <button class="btn-primary large" data-action="create-initial-workspace">Create a new workspace</button>
+            <button class="btn-secondary large" data-action="join-initial-workspace">Join an existing workspace</button>
+          </div>
         </div>
       `;
-      this.content.querySelector('#startWorkspaceBtn')?.addEventListener('click', showCreateWorkspaceModal);
+
+      const createButton = this.content.querySelector('[data-action="create-initial-workspace"]');
+      const joinButton = this.content.querySelector('[data-action="join-initial-workspace"]');
+
+      createButton?.addEventListener('click', showCreateWorkspaceModal);
+      joinButton?.addEventListener('click', showFindWorkspaceModal);
       return;
     }
 


### PR DESCRIPTION
## Summary
- update the empty workspace landing to explicitly ask whether to create a new workspace or join an existing one
- wire up the new call-to-action buttons to the existing create and find workspace flows
- add responsive styling so the new action buttons stack on small screens and sit side-by-side on larger screens

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d5bf2759f88332b0f13a1d56cf9cb2