### PR TITLE
Fix workspace creation modal handler

### DIFF
--- a/workspace.js
+++ b/workspace.js
@@ -196,6 +196,10 @@ function showCreateWorkspaceModal() {
   clearModal(form);
   openModal('createWorkspaceModal');
 
+  if (form._workspaceSubmitHandler) {
+    form.removeEventListener('submit', form._workspaceSubmitHandler);
+  }
+
   const handleSubmit = event => {
     event.preventDefault();
     const nameInput = form.querySelector('#workspaceName');
@@ -288,7 +292,8 @@ function showCreateWorkspaceModal() {
     enterWorkspace(workspace.id);
   };
 
-  form.addEventListener('submit', handleSubmit, { once: true });
+  form._workspaceSubmitHandler = handleSubmit;
+  form.addEventListener('submit', handleSubmit);
 }
 
 function renderWorkspaceDiscoveryList(searchTerm = '') {


### PR DESCRIPTION
## Summary
- ensure the create workspace form removes any previous submit handler before attaching a fresh one so subsequent submissions work after validation errors

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_b_68d5c54bb38c8332ac9c944cc382d180