### PR TITLE
Redesign workspace onboarding experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,14 @@
         <h1>Build a secure home for every team</h1>
         <p>Create Slack-style hubs with invite rules, approval workflows, and reusable channels that never disappear.</p>
         <div class="hero-actions">
-          <button id="createWorkspaceBtn" class="btn-primary large">Create Workspace</button>
-          <button id="findWorkspaceBtn" class="btn-secondary large">Find Workspace</button>
+          <button id="createWorkspaceBtn" class="btn-primary large">
+            <span class="btn-icon">✨</span>
+            <span>Create a workspace</span>
+          </button>
+          <button id="findWorkspaceBtn" class="btn-secondary large">
+            <span class="btn-icon">🔍</span>
+            <span>Join with an invite</span>
+          </button>
         </div>
       </div>
       <div class="hero-stats" id="workspaceHeroStats" aria-live="polite"></div>
@@ -290,38 +296,47 @@
 
   <div id="reentryContainer" hidden></div>
 
-  <!-- Create Workspace Modal -->
-  <div id="createWorkspaceModal" class="modal" hidden role="dialog" aria-modal="true" aria-labelledby="createWorkspaceTitle">
-    <div class="modal-content">
-      <h2 id="createWorkspaceTitle">Create New Workspace</h2>
-      <form id="createWorkspaceForm">
-        <p class="modal-error" role="alert" hidden></p>
-        <input type="text" id="workspaceName" placeholder="Workspace Name" required maxlength="50">
-        <textarea id="workspaceDesc" placeholder="Description (optional)" maxlength="200"></textarea>
-        <select id="workspaceType">
-          <option value="public">Public - Anyone can find</option>
-          <option value="private">Private - Invite only</option>
-        </select>
-        <select id="workspaceJoinRules">
-          <option value="open">Open - Anyone can join</option>
-          <option value="request">Request - Approval needed</option>
-          <option value="invite">Invite Only</option>
-        </select>
-        <div class="modal-actions">
-          <button type="submit" class="btn-primary">Create Workspace</button>
-          <button type="button" class="btn-secondary" data-action="close-modal" data-target="createWorkspaceModal">Cancel</button>
+  <div id="storagePassphraseModal" class="sheet-modal" hidden role="dialog" aria-modal="true" aria-labelledby="storagePassphraseTitle">
+    <div class="sheet-modal__overlay" data-action="close-passphrase"></div>
+    <div class="sheet-modal__content" role="document">
+      <button type="button" class="sheet-modal__close" data-action="close-passphrase" aria-label="Close passphrase dialog">✕</button>
+      <div class="sheet-modal__header">
+        <div class="sheet-modal__icon">🛡️</div>
+        <div>
+          <p class="sheet-modal__eyebrow">Encrypted history</p>
+          <h2 id="storagePassphraseTitle">Protect your saved conversations</h2>
+          <p class="sheet-modal__subtitle">Set a password so only you can unlock stored chats on this device.</p>
+        </div>
+      </div>
+      <form id="storagePassphraseForm" novalidate>
+        <div class="field-group">
+          <label for="storagePassphraseInput">Workspace history password</label>
+          <input type="password" id="storagePassphraseInput" minlength="8" autocomplete="new-password" placeholder="Enter a strong password" required>
+          <p class="field-hint">We'll use this password to encrypt messages saved locally. Keep it somewhere safe.</p>
+          <div class="strength-meter" id="storagePassphraseStrength" aria-live="polite">
+            <span class="strength-bar"></span>
+            <span class="strength-bar"></span>
+            <span class="strength-bar"></span>
+            <span class="strength-bar"></span>
+            <span class="strength-label" id="storagePassphraseStrengthText">Strength: weak</span>
+          </div>
+          <p class="field-error" id="storagePassphraseError" role="alert" hidden></p>
+        </div>
+        <div class="field-group inline">
+          <label class="toggle">
+            <input type="checkbox" id="storageRememberPassphrase" checked>
+            <span>Remember this password for the current session</span>
+          </label>
+          <p class="field-hint">We'll forget it as soon as you close the tab.</p>
+        </div>
+        <div class="sheet-modal__actions">
+          <button type="submit" class="btn-primary" data-loading-text="Encrypting…">
+            <span class="btn-icon">🔐</span>
+            <span class="btn-label">Save password</span>
+          </button>
+          <button type="button" class="btn-secondary" data-action="skip-passphrase">Not now</button>
         </div>
       </form>
-    </div>
-  </div>
-
-  <!-- Find Workspace Modal -->
-  <div id="findWorkspaceModal" class="modal" hidden role="dialog" aria-modal="true" aria-labelledby="findWorkspaceTitle">
-    <div class="modal-content">
-      <h2 id="findWorkspaceTitle">Find Workspaces</h2>
-      <input type="text" id="workspaceSearch" placeholder="Search or enter invite code">
-      <div id="workspaceList"></div>
-      <button class="btn-secondary" data-action="close-modal" data-target="findWorkspaceModal">Close</button>
     </div>
   </div>
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,3 +1,38 @@
+function computePassphraseStrength(value = '') {
+  if (!value || typeof value !== 'string') {
+    return 0;
+  }
+  let score = 0;
+  if (value.length >= 8) {
+    score += 1;
+  }
+  if (value.length >= 12) {
+    score += 1;
+  }
+  if (/[A-Z]/.test(value) && /[a-z]/.test(value)) {
+    score += 1;
+  }
+  if (/[0-9]/.test(value) || /[^A-Za-z0-9]/.test(value)) {
+    score += 1;
+  }
+  return Math.min(score, 4);
+}
+
+function describePassphraseStrength(level) {
+  switch (level) {
+    case 4:
+      return 'excellent';
+    case 3:
+      return 'strong';
+    case 2:
+      return 'good';
+    case 1:
+      return 'fair';
+    default:
+      return 'weak';
+  }
+}
+
 class StorageManager {
       constructor() {
         this.state = new ChatState();
@@ -9,6 +44,7 @@ class StorageManager {
         this.storageKey = null;
         this.storageSalt = null;
         this.lastVerification = null;
+        this._passphrasePromise = null;
         this.ready = this.init();
       }
 
@@ -113,36 +149,190 @@ class StorageManager {
           return null;
         }
 
+        if (this._passphrasePromise) {
+          return this._passphrasePromise;
+        }
+
+        const cacheKey = 'secure-chat-storage-passphrase';
+
         try {
-          const cached = sessionStorage.getItem('secure-chat-storage-passphrase');
+          const cached = sessionStorage.getItem(cacheKey);
           if (cached && cached.trim()) {
             return cached.trim();
           }
         } catch (error) {
-          // Session storage might be unavailable; ignore and fall through to prompt
+          // Session storage might be unavailable; ignore and continue with modal prompt
         }
 
-        const input = window.prompt(
-          'Enter a passphrase to encrypt stored chat history (leave blank to disable encryption).',
-          ''
-        );
+        const modal = document.getElementById('storagePassphraseModal');
+        const form = modal?.querySelector('#storagePassphraseForm');
+        const input = modal?.querySelector('#storagePassphraseInput');
 
-        if (typeof input !== 'string') {
-          return null;
+        if (!modal || !form || !input) {
+          const fallback = window.prompt(
+            'Enter a passphrase to encrypt stored chat history (leave blank to disable encryption).',
+            ''
+          );
+          if (typeof fallback !== 'string') {
+            return null;
+          }
+          const trimmedFallback = fallback.trim();
+          if (!trimmedFallback) {
+            return null;
+          }
+          try {
+            sessionStorage.setItem(cacheKey, trimmedFallback);
+          } catch (error) {
+            // Ignore storage failures and continue without caching the passphrase
+          }
+          return trimmedFallback;
         }
 
-        const trimmed = input.trim();
-        if (!trimmed) {
-          return null;
-        }
+        this._passphrasePromise = new Promise(resolve => {
+          const remember = form.querySelector('#storageRememberPassphrase');
+          const strengthMeter = form.querySelector('#storagePassphraseStrength');
+          const strengthText = form.querySelector('#storagePassphraseStrengthText');
+          const errorEl = form.querySelector('#storagePassphraseError');
+          const skipButton = form.querySelector('[data-action="skip-passphrase"]');
+          const closeElements = Array.from(modal.querySelectorAll('[data-action="close-passphrase"]'));
 
-        try {
-          sessionStorage.setItem('secure-chat-storage-passphrase', trimmed);
-        } catch (error) {
-          // Ignore storage failures and continue without caching the passphrase
-        }
+          const updateStrength = (value) => {
+            const level = computePassphraseStrength(value);
+            if (strengthMeter) {
+              strengthMeter.dataset.level = `${level}`;
+            }
+            if (strengthText) {
+              strengthText.textContent = `Strength: ${describePassphraseStrength(level)}`;
+            }
+          };
 
-        return trimmed;
+          const clearError = () => {
+            if (errorEl) {
+              errorEl.textContent = '';
+              errorEl.hidden = true;
+            }
+            const group = form.querySelector('.field-group');
+            group?.classList.remove('has-error');
+          };
+
+          const showError = (message) => {
+            if (errorEl) {
+              errorEl.textContent = message;
+              errorEl.hidden = false;
+            }
+            const group = form.querySelector('.field-group');
+            group?.classList.add('has-error');
+          };
+
+          const setLoading = (button, loading) => {
+            if (!button) {
+              return;
+            }
+            if (loading) {
+              button.setAttribute('data-loading', 'true');
+              const label = button.querySelector('.btn-label');
+              if (label && !button.dataset.originalLabel) {
+                button.dataset.originalLabel = label.textContent.trim();
+                const loadingText = button.getAttribute('data-loading-text') || 'Saving…';
+                label.textContent = loadingText;
+              }
+            } else {
+              button.removeAttribute('data-loading');
+              const label = button.querySelector('.btn-label');
+              if (label && button.dataset.originalLabel) {
+                label.textContent = button.dataset.originalLabel;
+                delete button.dataset.originalLabel;
+              }
+            }
+          };
+
+          const cleanup = () => {
+            form.removeEventListener('submit', handleSubmit);
+            input.removeEventListener('input', handleInput);
+            skipButton?.removeEventListener('click', handleClose);
+            closeElements.forEach(btn => btn.removeEventListener('click', handleClose));
+            document.removeEventListener('keydown', handleKeydown);
+            modal.hidden = true;
+            modal.setAttribute('aria-hidden', 'true');
+            modal.removeAttribute('data-open');
+            form.reset();
+            updateStrength('');
+            clearError();
+            this._passphrasePromise = null;
+          };
+
+          const handleClose = () => {
+            cleanup();
+            resolve(null);
+          };
+
+          const handleKeydown = (event) => {
+            if (event.key === 'Escape') {
+              event.preventDefault();
+              handleClose();
+            }
+          };
+
+          const handleInput = () => {
+            clearError();
+            updateStrength(input.value.trim());
+          };
+
+          const handleSubmit = async (event) => {
+            event.preventDefault();
+            clearError();
+            const value = input.value.trim();
+            if (!value) {
+              showError('Password is required to enable encryption.');
+              input.focus();
+              return;
+            }
+            if (value.length < 8) {
+              showError('Use at least 8 characters for a strong password.');
+              input.focus();
+              return;
+            }
+
+            const submitButton = form.querySelector('button[type="submit"]');
+            setLoading(submitButton, true);
+
+            try {
+              if (remember?.checked) {
+                try {
+                  sessionStorage.setItem(cacheKey, value);
+                } catch (error) {
+                  // Session storage optional; ignore failures
+                }
+              } else {
+                try {
+                  sessionStorage.removeItem(cacheKey);
+                } catch (error) {
+                  // Ignore removal errors
+                }
+              }
+              cleanup();
+              resolve(value);
+            } finally {
+              setLoading(submitButton, false);
+            }
+          };
+
+          skipButton?.addEventListener('click', handleClose);
+          closeElements.forEach(btn => btn.addEventListener('click', handleClose));
+          document.addEventListener('keydown', handleKeydown);
+          form.addEventListener('submit', handleSubmit);
+          input.addEventListener('input', handleInput);
+
+          modal.hidden = false;
+          modal.setAttribute('aria-hidden', 'false');
+          modal.dataset.open = 'true';
+          requestAnimationFrame(() => {
+            updateStrength(input.value.trim());
+            input.focus();
+          });
+        });
+
+        return this._passphrasePromise;
       }
 
       async getOrCreateStorageSalt() {

--- a/styles.css
+++ b/styles.css
@@ -198,6 +198,121 @@
       letter-spacing: 0.05em;
     }
 
+.btn-primary[data-loading="true"],
+.btn-secondary[data-loading="true"] {
+  position: relative;
+  pointer-events: none;
+  opacity: 0.7;
+}
+
+.btn-primary[data-loading="true"]::after,
+.btn-secondary[data-loading="true"]::after {
+  content: '';
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 999px;
+  right: 14px;
+  top: 50%;
+  margin-top: -8px;
+  animation: spin 0.75s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.sheet-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 3000;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+}
+
+.sheet-modal[hidden] {
+  display: none !important;
+}
+
+.sheet-modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.7);
+  backdrop-filter: blur(12px);
+}
+
+.sheet-modal__content {
+  position: relative;
+  z-index: 1;
+  max-width: min(480px, 100%);
+  width: 100%;
+  background: linear-gradient(180deg, #ffffff, #f8fafc);
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 2.25rem 2.5rem;
+  box-shadow: 0 45px 80px -50px rgba(15, 23, 42, 0.65);
+}
+
+.sheet-modal__close {
+  position: absolute;
+  top: 1.25rem;
+  right: 1.25rem;
+  border: 0;
+  background: rgba(15, 23, 42, 0.05);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
+.sheet-modal__close:hover {
+  background: rgba(15, 23, 42, 0.1);
+}
+
+.sheet-modal__header {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  margin-bottom: 1.5rem;
+}
+
+.sheet-modal__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: rgba(59, 130, 246, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  color: #1d4ed8;
+}
+
+.sheet-modal__eyebrow {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.sheet-modal__subtitle {
+  color: #475569;
+  line-height: 1.5;
+  margin-top: 0.35rem;
+}
+
+.sheet-modal__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
     .fingerprint-code {
       font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
       font-size: 0.875rem;
@@ -3009,39 +3124,544 @@
   flex-wrap: wrap;
 }
 
+.hero-actions .btn-primary,
+.hero-actions .btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  border-radius: 999px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero-actions .btn-primary:focus-visible,
+.hero-actions .btn-secondary:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.65);
+  outline-offset: 2px;
+}
+
+.hero-actions .btn-primary:hover,
+.hero-actions .btn-secondary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px -20px rgba(15, 23, 42, 0.55);
+}
+
+.btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  font-size: 1.05rem;
+}
+
+.btn-label {
+  display: inline-flex;
+  align-items: center;
+}
+
 .btn-primary.large,
 .btn-secondary.large {
   padding: 0.9rem 1.75rem;
   font-size: 1.05rem;
 }
 
+.btn-primary.small,
+.btn-secondary.small {
+  padding: 0.55rem 1rem;
+  font-size: 0.9rem;
+  border-radius: 12px;
+}
+
 .hero-stats {
-  display: flex;
-  align-items: center;
-  gap: 2rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
   position: relative;
   z-index: 1;
+  align-self: flex-end;
 }
 
-.hero-stats .stat {
+.stat-card {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.25rem;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem 1.25rem;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(12px);
 }
 
-.hero-stats .stat-number {
-  font-size: 2rem;
+.stat-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+}
+
+.stat-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  opacity: 0.8;
+}
+
+.stat-number {
+  font-size: 1.5rem;
   font-weight: 700;
-}
-
-.hero-stats .stat-label {
-  font-size: 0.9rem;
-  opacity: 0.85;
 }
 
 .workspace-content {
   min-height: 320px;
+}
+
+.workspace-landing {
+  display: grid;
+  gap: 2rem;
+}
+
+.workspace-flow {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 2rem;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 24px 50px -32px rgba(15, 23, 42, 0.35);
+  position: relative;
+  overflow: hidden;
+}
+
+.workspace-flow::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(99, 102, 241, 0.08));
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.workspace-flow__inner {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 1.75rem;
+}
+
+.workspace-flow__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.workspace-flow__header h2 {
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+  color: #0f172a;
+}
+
+.flow-kicker {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.workspace-flow__subtitle {
+  color: #475569;
+  line-height: 1.6;
+  max-width: 640px;
+}
+
+.flow-stepper {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.flow-step {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid #e2e8f0;
+  background: rgba(241, 245, 249, 0.8);
+  font-size: 0.85rem;
+  color: #475569;
+  transition: all 0.2s ease;
+}
+
+.flow-step[data-state="active"] {
+  border-color: #3b82f6;
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.flow-step[data-state="complete"] {
+  border-color: rgba(16, 185, 129, 0.35);
+  background: rgba(16, 185, 129, 0.12);
+  color: #047857;
+}
+
+.flow-step .step-index {
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: white;
+  border: 1px solid currentColor;
+  font-weight: 600;
+  font-size: 0.75rem;
+}
+
+.workspace-flow__toggle {
+  display: inline-flex;
+  background: #f1f5f9;
+  padding: 0.4rem;
+  border-radius: 999px;
+  border: 1px solid #e2e8f0;
+  width: fit-content;
+}
+
+.workspace-flow__toggle button {
+  border: 0;
+  background: transparent;
+  color: #1e293b;
+  font-weight: 600;
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.workspace-flow__toggle button[aria-pressed="true"] {
+  background: white;
+  color: #1d4ed8;
+  box-shadow: 0 10px 30px -20px rgba(30, 64, 175, 0.6);
+}
+
+.workspace-flow__toggle button:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.45);
+  outline-offset: 2px;
+}
+
+.workspace-flow__body {
+  background: white;
+  border-radius: 20px;
+  border: 1px solid #e2e8f0;
+  padding: 1.75rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.65);
+}
+
+.mode-select {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.mode-options {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.mode-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 18px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.8), rgba(255, 255, 255, 0.95));
+}
+
+.mode-card:hover,
+.mode-card:focus-visible {
+  border-color: #3b82f6;
+  box-shadow: 0 20px 40px -24px rgba(59, 130, 246, 0.35);
+  outline: none;
+}
+
+.mode-card__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.mode-card__label {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.mode-card__hint {
+  color: #475569;
+  line-height: 1.5;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.field-group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.field-group.inline {
+  gap: 0.75rem;
+}
+
+.field-group label {
+  font-weight: 600;
+  color: #0f172a;
+  display: flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.field-group.has-error input,
+.field-group.has-error textarea,
+.field-group.has-error select {
+  border-color: #dc2626;
+  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.15);
+}
+
+.field-group input,
+.field-group textarea,
+.field-group select {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid #cbd5f5;
+  padding: 0.8rem 1rem;
+  font-size: 1rem;
+  background: rgba(248, 250, 252, 0.9);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.field-group input:focus,
+.field-group textarea:focus,
+.field-group select:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+  background: #ffffff;
+}
+
+.field-hint {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.field-error {
+  font-size: 0.85rem;
+  color: #dc2626;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.toggle input {
+  width: 18px;
+  height: 18px;
+}
+
+.strength-meter {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.35rem;
+}
+
+.strength-bar {
+  width: 36px;
+  height: 6px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  transition: background 0.3s ease;
+}
+
+.strength-label {
+  font-size: 0.75rem;
+  color: #475569;
+  margin-left: 0.25rem;
+}
+
+.strength-meter[data-level="0"] .strength-bar:nth-child(-n+1) {
+  background: #ef4444;
+}
+
+.strength-meter[data-level="1"] .strength-bar:nth-child(-n+2) {
+  background: #f97316;
+}
+
+.strength-meter[data-level="2"] .strength-bar:nth-child(-n+3) {
+  background: #facc15;
+}
+
+.strength-meter[data-level="3"] .strength-bar:nth-child(-n+4) {
+  background: #22c55e;
+}
+
+.strength-meter[data-level="4"] .strength-bar {
+  background: #16a34a;
+}
+
+.workspace-flow__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.workspace-flow__actions .btn-secondary {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+.workspace-flow__actions .btn-secondary:hover {
+  background: #cbd5f5;
+}
+
+.workspace-flow__callout {
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px dashed rgba(59, 130, 246, 0.4);
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+  color: #1d4ed8;
+  font-size: 0.9rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.workspace-flow__list {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.join-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+  background: white;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.join-card:hover {
+  border-color: #3b82f6;
+  box-shadow: 0 18px 36px -28px rgba(59, 130, 246, 0.35);
+}
+
+.join-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.join-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.join-card__badge {
+  background: #f1f5f9;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+}
+
+.join-empty {
+  border-radius: 14px;
+  padding: 1.25rem;
+  background: rgba(15, 23, 42, 0.04);
+  color: #475569;
+}
+
+.security-panel {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.security-panel__explain {
+  background: rgba(15, 23, 42, 0.04);
+  border-radius: 16px;
+  padding: 1.25rem 1.5rem;
+  color: #1e293b;
+  line-height: 1.5;
+}
+
+.success-panel {
+  display: grid;
+  gap: 1.5rem;
+  text-align: left;
+}
+
+.success-panel__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(16, 185, 129, 0.12);
+  color: #047857;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.success-panel__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.success-panel__actions .btn-secondary.copied {
+  background: #22c55e;
+  color: white;
+}
+
+.success-panel__meta {
+  display: grid;
+  gap: 0.5rem;
+  color: #475569;
+}
+
+.success-meta__row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.success-meta__row code {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
 }
 
 .workspace-empty {
@@ -3075,6 +3695,26 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 1.5rem;
+}
+
+.workspace-grid__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.workspace-grid__header h3 {
+  color: #0f172a;
+}
+
+.workspace-grid__header .btn-secondary {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+.workspace-grid__header .btn-secondary:hover {
+  background: #cbd5f5;
 }
 
 .workspace-card {
@@ -3142,6 +3782,8 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
   font-size: 0.85rem;
   color: #475569;
 }

--- a/workspace.js
+++ b/workspace.js
@@ -134,387 +134,103 @@ function updateWorkspace(workspaceId, updater) {
   return next;
 }
 
-function openModal(id) {
-  const modal = document.getElementById(id);
-  if (!modal) {
-    return;
+function ensureUniqueWorkspaceId() {
+  let workspaceId = generateWorkspaceId();
+  while (readWorkspace(workspaceId)) {
+    workspaceId = generateWorkspaceId();
   }
-  modal.hidden = false;
-  modal.setAttribute('aria-hidden', 'false');
-  modal.dataset.open = 'true';
-  modal.focus?.();
+  return workspaceId;
 }
 
-function closeModal(id) {
-  const modal = document.getElementById(id);
-  if (!modal) {
-    return;
+function evaluatePasswordStrength(value = '') {
+  if (!value || typeof value !== 'string') {
+    return 0;
   }
-  modal.hidden = true;
-  modal.setAttribute('aria-hidden', 'true');
-  delete modal.dataset.open;
-
-  if (id === 'findWorkspaceModal') {
-    const searchInput = document.getElementById('workspaceSearch');
-    if (searchInput && searchInput._workspaceHandler) {
-      searchInput.removeEventListener('input', searchInput._workspaceHandler);
-      delete searchInput._workspaceHandler;
-    }
+  let score = 0;
+  if (value.length >= 8) {
+    score += 1;
   }
+  if (value.length >= 12) {
+    score += 1;
+  }
+  if (/[A-Z]/.test(value) && /[a-z]/.test(value)) {
+    score += 1;
+  }
+  if (/[0-9]/.test(value) || /[^A-Za-z0-9]/.test(value)) {
+    score += 1;
+  }
+  return Math.min(score, 4);
 }
 
-document.addEventListener('click', event => {
-  const button = event.target.closest('[data-action="close-modal"]');
-  if (!button) {
-    return;
-  }
-  const target = button.getAttribute('data-target');
-  if (target) {
-    closeModal(target);
-  }
-});
-
-function clearModal(form) {
-  if (!form) {
-    return;
-  }
-  form.reset?.();
-  const message = form.querySelector('.modal-error');
-  if (message) {
-    message.textContent = '';
-    message.hidden = true;
+function describeStrength(level) {
+  switch (level) {
+    case 4:
+      return 'excellent';
+    case 3:
+      return 'strong';
+    case 2:
+      return 'good';
+    case 1:
+      return 'fair';
+    default:
+      return 'weak';
   }
 }
 
-function showCreateWorkspaceModal() {
-  const modal = document.getElementById('createWorkspaceModal');
-  const form = document.getElementById('createWorkspaceForm');
-  if (!modal || !form) {
-    return;
+async function hashWorkspaceSecret(secret) {
+  if (!secret) {
+    return null;
   }
-
-  clearModal(form);
-  openModal('createWorkspaceModal');
-
-  if (form._workspaceSubmitHandler) {
-    form.removeEventListener('submit', form._workspaceSubmitHandler);
-  }
-
-  const handleSubmit = event => {
-    event.preventDefault();
-    const nameInput = form.querySelector('#workspaceName');
-    const descInput = form.querySelector('#workspaceDesc');
-    const typeInput = form.querySelector('#workspaceType');
-    const joinRulesInput = form.querySelector('#workspaceJoinRules');
-    const message = form.querySelector('.modal-error');
-
-    const name = nameInput?.value.trim() || '';
-    const description = descInput?.value.trim() || '';
-    const type = typeInput?.value === 'private' ? 'private' : 'public';
-    const joinRules = ['open', 'request', 'invite'].includes(joinRulesInput?.value)
-      ? joinRulesInput.value
-      : 'open';
-
-    if (!name) {
-      if (message) {
-        message.textContent = 'Workspace name is required.';
-        message.hidden = false;
-      }
-      nameInput?.focus();
-      return;
-    }
-
-    if (name.length > 50) {
-      if (message) {
-        message.textContent = 'Workspace name must be 50 characters or fewer.';
-        message.hidden = false;
-      }
-      nameInput?.focus();
-      return;
-    }
-
-    if (description.length > 200) {
-      if (message) {
-        message.textContent = 'Description must be 200 characters or fewer.';
-        message.hidden = false;
-      }
-      descInput?.focus();
-      return;
-    }
-
-    let workspaceId = generateWorkspaceId();
-    while (readWorkspace(workspaceId)) {
-      workspaceId = generateWorkspaceId();
-    }
-
-    const inviteCode = generateInviteCode();
-    const creatorPeerId = window.App?.peer?.id || null;
-    const profile = getLocalWorkspaceProfile();
-
-    const workspace = ensureWorkspaceShape({
-      id: workspaceId,
-      name,
-      description,
-      type,
-      joinRules,
-      created: Date.now(),
-      creatorPeerId,
-      members: [
-        {
-          id: profile.id,
-          name: profile.name,
-          peerId: creatorPeerId,
-          role: 'owner',
-          joined: Date.now()
-        }
-      ],
-      channels: [
-        { id: 'general', name: 'General', created: Date.now() }
-      ],
-      inviteCode,
-      requests: []
-    });
-
-    try {
-      saveWorkspace(workspace);
-    } catch (error) {
-      console.warn('Unable to save workspace', error);
-      if (message) {
-        message.textContent = 'Unable to save workspace. Storage quota may be full.';
-        message.hidden = false;
-      }
-      return;
-    }
-
-    closeModal('createWorkspaceModal');
-    window.workspaceApp?.renderLanding();
-    updateWorkspaceStats();
-    enterWorkspace(workspace.id);
-  };
-
-  form._workspaceSubmitHandler = handleSubmit;
-  form.addEventListener('submit', handleSubmit);
+  const encoder = new TextEncoder();
+  const data = encoder.encode(secret);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest)).map(byte => byte.toString(16).padStart(2, '0')).join('');
 }
 
-function renderWorkspaceDiscoveryList(searchTerm = '') {
-  const listEl = document.getElementById('workspaceList');
-  if (!listEl) {
-    return;
+function getWorkspaceByInvite(code) {
+  if (!code) {
+    return null;
   }
-  listEl.innerHTML = '';
-
+  const normalized = code.replace(/[^a-z0-9]/gi, '').toUpperCase();
+  if (!normalized) {
+    return null;
+  }
   const all = listWorkspaces();
-  const normalizedSearch = searchTerm.trim().toLowerCase();
-  const inviteSearch = normalizedSearch.replace(/[^a-z0-9]/gi, '').toUpperCase();
+  return all.find(workspace => workspace.id.toUpperCase() === normalized
+    || workspace.inviteCode === normalized);
+}
 
-  const filtered = all.filter(workspace => {
-    const matchesTerm = !normalizedSearch
-      || workspace.name.toLowerCase().includes(normalizedSearch)
-      || workspace.id.toLowerCase().includes(normalizedSearch)
-      || (workspace.inviteCode && workspace.inviteCode.toLowerCase().includes(normalizedSearch));
-
-    if (!normalizedSearch) {
-      return workspace.type === 'public';
-    }
-
-    if (workspace.type === 'public') {
-      return matchesTerm;
-    }
-
-    if (inviteSearch && workspace.inviteCode === inviteSearch) {
-      return true;
-    }
-
-    return matchesTerm;
-  });
-
-  if (!filtered.length) {
-    const empty = document.createElement('div');
-    empty.className = 'workspace-empty-result';
-    empty.textContent = 'No workspaces found. Try a different search or request an invite code.';
-    listEl.appendChild(empty);
+function renderHeroStats(statsEl, workspaces = []) {
+  if (!statsEl) {
     return;
   }
+  const workspaceCount = workspaces.length;
+  const totalMembers = workspaces.reduce((sum, workspace) => sum + (workspace.members?.length || 0), 0);
+  const pendingRequests = workspaces.reduce((sum, workspace) => sum + (workspace.requests?.length || 0), 0);
 
-  filtered.forEach(workspace => {
-    const card = document.createElement('article');
-    card.className = 'discovery-card';
-    card.dataset.workspaceId = workspace.id;
-    card.innerHTML = `
-      <header class="discovery-card__header">
-        <div class="discovery-card__icon">${workspace.name.charAt(0).toUpperCase()}</div>
-        <div>
-          <h3>${workspace.name}</h3>
-          <p>${workspace.description || 'No description provided.'}</p>
-        </div>
-      </header>
-      <div class="discovery-card__meta">
-        <span>${workspace.type === 'public' ? 'Public' : 'Private'}</span>
-        <span>${formatJoinRule(workspace.joinRules)}</span>
-        <span>${workspace.members.length} members</span>
+  statsEl.innerHTML = `
+    <div class="stat-card">
+      <div class="stat-icon">🗂️</div>
+      <div>
+        <div class="stat-label">Active workspaces</div>
+        <div class="stat-number">${workspaceCount}</div>
       </div>
-      <div class="discovery-card__actions">
-        ${renderDiscoveryAction(workspace, inviteSearch)}
+    </div>
+    <div class="stat-card">
+      <div class="stat-icon">🧑‍🤝‍🧑</div>
+      <div>
+        <div class="stat-label">People connected</div>
+        <div class="stat-number">${totalMembers}</div>
       </div>
-    `;
-
-    bindDiscoveryCardActions(card, workspace, inviteSearch);
-    listEl.appendChild(card);
-  });
-}
-
-function renderDiscoveryAction(workspace, inviteSearch) {
-  if (workspace.joinRules === 'request') {
-    return `
-      <button class="btn-primary" data-action="request">Request to Join</button>
-      <form class="request-form" data-role="request" hidden>
-        <input type="text" name="name" placeholder="Your name" required maxlength="50">
-        <textarea name="message" placeholder="Introduce yourself" maxlength="250"></textarea>
-        <div class="form-actions">
-          <button type="submit" class="btn-primary">Send Request</button>
-          <button type="button" class="btn-secondary" data-action="cancel-request">Cancel</button>
-        </div>
-        <p class="form-hint">An admin will review your request.</p>
-      </form>
-    `;
-  }
-
-  if (workspace.joinRules === 'invite') {
-    const prefill = inviteSearch && inviteSearch === workspace.inviteCode ? inviteSearch : '';
-    return `
-      <div class="invite-join">
-        <input type="text" name="invite" placeholder="Invite code" value="${prefill}" maxlength="6">
-        <button class="btn-primary" data-action="join-with-invite">Join</button>
-        <p class="form-hint">Invite-only workspace.</p>
+    </div>
+    <div class="stat-card">
+      <div class="stat-icon">🛎️</div>
+      <div>
+        <div class="stat-label">Pending requests</div>
+        <div class="stat-number">${pendingRequests}</div>
       </div>
-    `;
-  }
-
-  return `<button class="btn-primary" data-action="join-open">Join Workspace</button>`;
-}
-
-function bindDiscoveryCardActions(card, workspace, inviteSearch) {
-  const joinOpen = card.querySelector('[data-action="join-open"]');
-  if (joinOpen) {
-    joinOpen.addEventListener('click', () => {
-      handleOpenJoin(workspace);
-    });
-  }
-
-  const requestBtn = card.querySelector('[data-action="request"]');
-  const requestForm = card.querySelector('form[data-role="request"]');
-  if (requestBtn && requestForm) {
-    requestBtn.addEventListener('click', () => {
-      requestBtn.hidden = true;
-      requestForm.hidden = false;
-      const nameField = requestForm.querySelector('input[name="name"]');
-      nameField?.focus();
-    });
-
-    const cancel = requestForm.querySelector('[data-action="cancel-request"]');
-    cancel?.addEventListener('click', () => {
-      requestForm.reset();
-      requestForm.hidden = true;
-      requestBtn.hidden = false;
-    });
-
-    requestForm.addEventListener('submit', event => {
-      event.preventDefault();
-      const formData = new FormData(requestForm);
-      const name = (formData.get('name') || '').toString().trim();
-      const message = (formData.get('message') || '').toString().trim();
-
-      if (!name) {
-        return;
-      }
-
-      handleRequestJoin(workspace, { name, message });
-      requestForm.innerHTML = '<p class="form-success">Request sent! An admin will get back to you soon.</p>';
-    });
-  }
-
-  const inviteJoin = card.querySelector('[data-action="join-with-invite"]');
-  if (inviteJoin) {
-    inviteJoin.addEventListener('click', () => {
-      const input = card.querySelector('input[name="invite"]');
-      const code = input?.value.trim().toUpperCase();
-      if (!code) {
-        input?.focus();
-        input?.classList.add('input-error');
-        return;
-      }
-      input?.classList.remove('input-error');
-      handleInviteJoin(workspace, code);
-    });
-  }
-
-  if (workspace.joinRules === 'invite' && inviteSearch && inviteSearch === workspace.inviteCode) {
-    const input = card.querySelector('input[name="invite"]');
-    if (input && !input.value) {
-      input.value = inviteSearch;
-    }
-  }
-}
-
-function handleOpenJoin(workspace) {
-  const profile = getLocalWorkspaceProfile();
-  const existingMember = workspace.members.find(member => member.id === profile.id);
-  if (!existingMember) {
-    workspace.members.push({
-      id: profile.id,
-      name: profile.name,
-      peerId: window.App?.peer?.id || null,
-      role: workspace.members.length ? 'member' : 'owner',
-      joined: Date.now()
-    });
-  }
-  saveWorkspace(workspace);
-  updateWorkspaceStats();
-  closeModal('findWorkspaceModal');
-  window.workspaceApp?.renderLanding();
-  enterWorkspace(workspace.id);
-}
-
-function handleInviteJoin(workspace, code) {
-  if (code !== workspace.inviteCode) {
-    alert('Invalid invite code for this workspace.');
-    return;
-  }
-  handleOpenJoin(workspace);
-}
-
-function handleRequestJoin(workspace, request) {
-  workspace.requests = Array.isArray(workspace.requests) ? workspace.requests : [];
-  workspace.requests.push({
-    id: `req-${generateSecureId().slice(0, 10)}`,
-    name: request.name,
-    message: request.message,
-    submitted: Date.now()
-  });
-  saveWorkspace(workspace);
-  updateWorkspaceStats();
-}
-
-function showFindWorkspaceModal() {
-  const modal = document.getElementById('findWorkspaceModal');
-  const searchInput = document.getElementById('workspaceSearch');
-  if (!modal || !searchInput) {
-    return;
-  }
-
-  openModal('findWorkspaceModal');
-  renderWorkspaceDiscoveryList(searchInput.value || '');
-  searchInput.focus();
-
-  const handleInput = event => {
-    renderWorkspaceDiscoveryList(event.target.value || '');
-  };
-
-  if (searchInput._workspaceHandler) {
-    searchInput.removeEventListener('input', searchInput._workspaceHandler);
-  }
-  searchInput._workspaceHandler = handleInput;
-  searchInput.addEventListener('input', handleInput);
+    </div>
+  `;
 }
 
 function enterWorkspace(workspaceId) {
@@ -681,12 +397,27 @@ function formatJoinRule(rule) {
   }
 }
 
+
 class WorkspaceApp {
   constructor() {
     this.root = document.getElementById('workspaceApp');
     this.content = document.getElementById('workspaceContent');
     this.heroStats = document.getElementById('workspaceHeroStats');
+    this.flowContainer = null;
+    this.flowBody = null;
+    this.librarySection = null;
+    this.toggleContainer = null;
+    this.stepIndicators = [];
+    this.workspaces = listWorkspaces();
     this.activeWorkspaceId = null;
+    this.currentJoinSearch = '';
+    this.flowState = {
+      step: 'mode',
+      mode: null,
+      draft: null,
+      joinTarget: null,
+      resultWorkspace: null
+    };
 
     if (this.root) {
       this.renderLanding();
@@ -697,71 +428,919 @@ class WorkspaceApp {
     this.activeWorkspaceId = id;
   }
 
+  startFlow(mode) {
+    this.selectMode(mode, { reset: true, scroll: true });
+  }
+
+  scrollFlowIntoView() {
+    if (this.flowContainer) {
+      this.flowContainer.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }
+
   renderLanding() {
     if (!this.content) {
       return;
     }
 
-    updateWorkspaceStats();
-    const workspaces = listWorkspaces();
+    this.workspaces = listWorkspaces();
+
+    if (!this.flowState) {
+      this.flowState = {
+        step: 'mode',
+        mode: null,
+        draft: null,
+        joinTarget: null,
+        resultWorkspace: null
+      };
+    }
+
+    this.content.innerHTML = `
+      <div class="workspace-landing">
+        <section id="workspaceFlowSection"></section>
+        <section id="workspaceLibrarySection" aria-live="polite"></section>
+      </div>
+    `;
+
+    this.flowContainer = this.content.querySelector('#workspaceFlowSection');
+    this.librarySection = this.content.querySelector('#workspaceLibrarySection');
+
+    this.renderFlowShell();
+    this.renderWorkspaceList(this.workspaces);
+    this.updateHeroStats();
+  }
+
+  renderFlowShell() {
+    if (!this.flowContainer) {
+      return;
+    }
+
+    const steps = [
+      { id: 'mode', label: 'Choose action' },
+      { id: 'details', label: 'Workspace details' },
+      { id: 'security', label: 'Security check' },
+      { id: 'success', label: 'All set' }
+    ];
+
+    const stepper = steps.map((step, index) => `
+      <div class="flow-step" data-step-index="${step.id}" data-state="pending">
+        <span class="step-index">${index + 1}</span>
+        <span>${step.label}</span>
+      </div>
+    `).join('');
+
+    this.flowContainer.innerHTML = `
+      <div class="workspace-flow">
+        <div class="workspace-flow__inner">
+          <header class="workspace-flow__header">
+            <div>
+              <span class="flow-kicker">Guided setup</span>
+              <h2>Get your team into a secure workspace</h2>
+              <p class="workspace-flow__subtitle">Follow the guided steps to create a new workspace or join one that you have been invited to.</p>
+            </div>
+            <div class="flow-stepper" role="list">
+              ${stepper}
+            </div>
+          </header>
+          <div class="workspace-flow__toggle" role="tablist">
+            <button type="button" data-mode="create" role="tab" aria-selected="false" aria-pressed="false">
+              <span class="btn-icon">✨</span>
+              <span class="btn-label">Create workspace</span>
+            </button>
+            <button type="button" data-mode="join" role="tab" aria-selected="false" aria-pressed="false">
+              <span class="btn-icon">🔗</span>
+              <span class="btn-label">Join workspace</span>
+            </button>
+          </div>
+          <div class="workspace-flow__body" id="workspaceFlowBody"></div>
+        </div>
+      </div>
+    `;
+
+    this.flowBody = this.flowContainer.querySelector('#workspaceFlowBody');
+    this.toggleContainer = this.flowContainer.querySelector('.workspace-flow__toggle');
+    this.stepIndicators = Array.from(this.flowContainer.querySelectorAll('.flow-step'));
+
+    const toggleButtons = Array.from(this.toggleContainer.querySelectorAll('button[data-mode]'));
+    toggleButtons.forEach(button => {
+      button.addEventListener('click', () => {
+        const mode = button.getAttribute('data-mode');
+        this.selectMode(mode, { reset: false, scroll: false });
+      });
+    });
+
+    this.updateFlowUI();
+  }
+
+  updateFlowUI() {
+    if (!this.flowContainer) {
+      return;
+    }
+
+    const stepOrder = ['mode', 'details', 'security', 'success'];
+    const currentIndex = stepOrder.indexOf(this.flowState.step);
+
+    this.stepIndicators.forEach(stepEl => {
+      const stepId = stepEl.getAttribute('data-step-index');
+      const position = stepOrder.indexOf(stepId);
+      if (position < currentIndex) {
+        stepEl.dataset.state = 'complete';
+      } else if (position === currentIndex) {
+        stepEl.dataset.state = 'active';
+      } else {
+        stepEl.dataset.state = 'pending';
+      }
+    });
+
+    if (this.toggleContainer) {
+      const isChoosing = this.flowState.step === 'mode';
+      this.toggleContainer.hidden = isChoosing;
+
+      const toggleButtons = Array.from(this.toggleContainer.querySelectorAll('button[data-mode]'));
+      toggleButtons.forEach(button => {
+        const mode = button.getAttribute('data-mode');
+        const active = !isChoosing && this.flowState.mode === mode;
+        button.setAttribute('aria-pressed', active ? 'true' : 'false');
+        button.setAttribute('aria-selected', active ? 'true' : 'false');
+      });
+    }
+
+    this.renderFlowBody();
+  }
+
+  renderFlowBody() {
+    if (!this.flowBody) {
+      return;
+    }
+
+    const { step, mode } = this.flowState;
+
+    if (step === 'mode') {
+      this.renderModeSelection();
+      return;
+    }
+
+    if (mode === 'create') {
+      if (step === 'details') {
+        this.renderCreateDetailsForm();
+        return;
+      }
+      if (step === 'security') {
+        this.renderCreateSecurityStep();
+        return;
+      }
+      if (step === 'success') {
+        this.renderSuccessStep();
+        return;
+      }
+    }
+
+    if (mode === 'join') {
+      if (step === 'details') {
+        this.renderJoinDetailsForm();
+        return;
+      }
+      if (step === 'security') {
+        this.renderJoinSecurityStep();
+        return;
+      }
+      if (step === 'success') {
+        this.renderSuccessStep();
+      }
+    }
+  }
+
+  renderModeSelection() {
+    this.flowBody.innerHTML = `
+      <div class="mode-select">
+        <p class="workspace-flow__subtitle">Pick how you would like to get started. You can always switch paths later.</p>
+        <div class="mode-options">
+          <button type="button" class="mode-card" data-select-mode="create">
+            <div class="mode-card__icon">🏗️</div>
+            <div class="mode-card__label">Create a workspace</div>
+            <p class="mode-card__hint">Launch a fresh hub with reusable channels, invite controls, and security baked in.</p>
+          </button>
+          <button type="button" class="mode-card" data-select-mode="join">
+            <div class="mode-card__icon">🎟️</div>
+            <div class="mode-card__label">Join with an invite</div>
+            <p class="mode-card__hint">Use an invite code or workspace URL that someone shared with you.</p>
+          </button>
+        </div>
+      </div>
+    `;
+
+    this.flowBody.querySelectorAll('[data-select-mode]').forEach(button => {
+      button.addEventListener('click', () => {
+        const mode = button.getAttribute('data-select-mode');
+        this.selectMode(mode, { reset: true, scroll: true });
+      });
+    });
+  }
+
+  renderCreateDetailsForm() {
+    const draft = this.flowState.draft || {};
+
+    this.flowBody.innerHTML = `
+      <form id="createWorkspaceDetails" class="form-grid" novalidate>
+        <div class="field-group" data-field="workspaceName">
+          <label for="createWorkspaceName">Workspace name <span aria-hidden="true">*</span></label>
+          <input id="createWorkspaceName" name="workspaceName" maxlength="50" placeholder="e.g. Support team HQ" value="${draft.name || ''}" required>
+          <p class="field-hint">This name appears on invites and inside the workspace header.</p>
+          <p class="field-error" hidden></p>
+        </div>
+        <div class="field-group" data-field="workspaceDesc">
+          <label for="createWorkspaceDesc">Description</label>
+          <textarea id="createWorkspaceDesc" name="workspaceDesc" maxlength="200" placeholder="What will this workspace be used for?">${draft.description || ''}</textarea>
+          <p class="field-hint">Optional, but helps teammates understand the purpose.</p>
+          <p class="field-error" hidden></p>
+        </div>
+        <div class="field-group" data-field="workspaceType">
+          <label for="createWorkspaceType">Visibility</label>
+          <select id="createWorkspaceType" name="workspaceType">
+            <option value="public" ${draft.type !== 'private' ? 'selected' : ''}>Public – discoverable to everyone on this device</option>
+            <option value="private" ${draft.type === 'private' ? 'selected' : ''}>Private – invite only</option>
+          </select>
+          <p class="field-hint">Public workspaces are listed in discovery. Private workspaces require an invite code.</p>
+        </div>
+        <div class="field-group" data-field="workspaceJoinRules">
+          <label for="createWorkspaceJoin">Join rule</label>
+          <select id="createWorkspaceJoin" name="workspaceJoinRules">
+            <option value="open" ${draft.joinRules === 'open' ? 'selected' : ''}>Open – anyone with the link can join</option>
+            <option value="request" ${draft.joinRules === 'request' ? 'selected' : ''}>Request – new members need approval</option>
+            <option value="invite" ${draft.joinRules === 'invite' ? 'selected' : ''}>Invite only – invite code required</option>
+          </select>
+          <p class="field-hint">Choose how teammates get access. You can change this later in settings.</p>
+        </div>
+        <div class="workspace-flow__actions">
+          <button type="submit" class="btn-primary large" data-loading-text="Saving…">
+            <span class="btn-icon">➡️</span>
+            <span class="btn-label">Continue to security</span>
+          </button>
+          <button type="button" class="btn-secondary" data-action="back-to-mode">Back</button>
+        </div>
+        <div class="workspace-flow__callout" role="note">
+          <span>💡</span>
+          <span>You can fine-tune channels and member permissions after the workspace is created.</span>
+        </div>
+      </form>
+    `;
+
+    const form = this.flowBody.querySelector('#createWorkspaceDetails');
+    form.addEventListener('submit', event => {
+      event.preventDefault();
+      this.handleCreateDetailsSubmit(form);
+    });
+
+    const backButton = form.querySelector('[data-action="back-to-mode"]');
+    backButton?.addEventListener('click', () => this.resetFlow());
+  }
+
+  handleCreateDetailsSubmit(form) {
+    this.clearFormErrors(form);
+
+    const nameInput = form.querySelector('#createWorkspaceName');
+    const descInput = form.querySelector('#createWorkspaceDesc');
+    const typeInput = form.querySelector('#createWorkspaceType');
+    const joinInput = form.querySelector('#createWorkspaceJoin');
+
+    const name = nameInput?.value.trim() || '';
+    const description = descInput?.value.trim() || '';
+    const type = typeInput?.value === 'private' ? 'private' : 'public';
+    const joinRules = ['open', 'request', 'invite'].includes(joinInput?.value)
+      ? joinInput.value
+      : 'open';
+
+    if (!name) {
+      this.setFieldError(form, 'workspaceName', 'Workspace name is required.');
+      nameInput?.focus();
+      return;
+    }
+
+    if (name.length > 50) {
+      this.setFieldError(form, 'workspaceName', 'Keep the name under 50 characters.');
+      nameInput?.focus();
+      return;
+    }
+
+    if (description.length > 200) {
+      this.setFieldError(form, 'workspaceDesc', 'Descriptions are limited to 200 characters.');
+      descInput?.focus();
+      return;
+    }
+
+    this.flowState.draft = {
+      name,
+      description,
+      type,
+      joinRules
+    };
+    this.flowState.mode = 'create';
+    this.flowState.step = 'security';
+    this.updateFlowUI();
+    this.scrollFlowIntoView();
+  }
+
+  renderCreateSecurityStep() {
+    const draft = this.flowState.draft;
+    if (!draft) {
+      this.flowState.step = 'details';
+      this.updateFlowUI();
+      return;
+    }
+
+    const strengthLevel = draft.securityStrength || 0;
+
+    this.flowBody.innerHTML = `
+      <div class="security-panel">
+        <div class="security-panel__explain">
+          <strong>${draft.name}</strong> will be locked behind a password so only approved teammates can access settings and history. Choose a strong password and decide if two-factor approvals are required.
+        </div>
+        <form id="createWorkspaceSecurity" class="form-grid" novalidate>
+          <div class="field-group" data-field="workspacePassword">
+            <label for="createWorkspacePassword">Workspace password</label>
+            <input type="password" id="createWorkspacePassword" name="workspacePassword" minlength="8" placeholder="Create a secure password" autocomplete="new-password">
+            <p class="field-hint">Protects workspace settings, invite creation, and encrypted message history.</p>
+            <div class="strength-meter" id="createWorkspaceStrength" data-level="${strengthLevel}">
+              <span class="strength-bar"></span>
+              <span class="strength-bar"></span>
+              <span class="strength-bar"></span>
+              <span class="strength-bar"></span>
+              <span class="strength-bar"></span>
+              <span class="strength-label" id="createWorkspaceStrengthText">Strength: ${describeStrength(strengthLevel)}</span>
+            </div>
+            <p class="field-error" hidden></p>
+          </div>
+          <div class="field-group inline" data-field="workspaceTwoFactor">
+            <label class="toggle">
+              <input type="checkbox" id="createWorkspace2FA" name="workspaceTwoFactor" ${draft.twoFactor ? 'checked' : ''}>
+              <span>Require 2FA approval for new members</span>
+            </label>
+            <p class="field-hint">We’ll prompt members to confirm via a second factor before they’re added.</p>
+          </div>
+          <p class="field-error" id="createSecurityError" role="alert" hidden></p>
+          <div class="workspace-flow__actions">
+            <button type="submit" class="btn-primary large" data-loading-text="Finalising…">
+              <span class="btn-icon">🛡️</span>
+              <span class="btn-label">Complete setup</span>
+            </button>
+            <button type="button" class="btn-secondary" data-action="back-to-details">Back</button>
+            <button type="button" class="btn-secondary" data-action="skip-security">Skip password</button>
+          </div>
+        </form>
+      </div>
+    `;
+
+    const form = this.flowBody.querySelector('#createWorkspaceSecurity');
+    const passwordInput = form.querySelector('#createWorkspacePassword');
+    const strengthMeter = form.querySelector('#createWorkspaceStrength');
+    const strengthText = form.querySelector('#createWorkspaceStrengthText');
+
+    passwordInput?.addEventListener('input', () => {
+      const value = passwordInput.value.trim();
+      const level = evaluatePasswordStrength(value);
+      if (strengthMeter) {
+        strengthMeter.dataset.level = `${level}`;
+      }
+      if (strengthText) {
+        strengthText.textContent = `Strength: ${describeStrength(level)}`;
+      }
+    });
+
+    form.addEventListener('submit', event => {
+      event.preventDefault();
+      this.handleCreateSecuritySubmit(form);
+    });
+
+    form.querySelector('[data-action="back-to-details"]')?.addEventListener('click', () => {
+      this.flowState.step = 'details';
+      this.updateFlowUI();
+    });
+
+    form.querySelector('[data-action="skip-security"]')?.addEventListener('click', async () => {
+      await this.completeWorkspaceSetup({ password: '', twoFactor: form.querySelector('#createWorkspace2FA')?.checked || false });
+    });
+  }
+
+  async handleCreateSecuritySubmit(form) {
+    this.clearFormErrors(form);
+    const passwordInput = form.querySelector('#createWorkspacePassword');
+    const twoFactorInput = form.querySelector('#createWorkspace2FA');
+    const errorMessage = form.querySelector('#createSecurityError');
+    const submitButton = form.querySelector('button[type="submit"]');
+
+    const password = passwordInput?.value.trim() || '';
+    if (password && password.length < 8) {
+      this.setFieldError(form, 'workspacePassword', 'Passwords should be at least 8 characters long.');
+      passwordInput?.focus();
+      return;
+    }
+
+    if (password && evaluatePasswordStrength(password) < 1) {
+      this.setFieldError(form, 'workspacePassword', 'Try mixing upper and lower case letters, numbers, or symbols for a stronger password.');
+      passwordInput?.focus();
+      return;
+    }
+
+    this.setButtonLoading(submitButton, true);
+    try {
+      await this.completeWorkspaceSetup({ password, twoFactor: twoFactorInput?.checked || false });
+    } catch (error) {
+      console.warn('Unable to create workspace', error);
+      if (errorMessage) {
+        errorMessage.textContent = 'Unable to save workspace. Your browser storage may be full.';
+        errorMessage.hidden = false;
+      }
+    } finally {
+      this.setButtonLoading(submitButton, false);
+    }
+  }
+
+  async completeWorkspaceSetup({ password, twoFactor }) {
+    const draft = this.flowState.draft;
+    if (!draft) {
+      return;
+    }
+
+    const now = Date.now();
+    const workspaceId = ensureUniqueWorkspaceId();
+    const inviteCode = generateInviteCode();
+    const creatorPeerId = window.App?.peer?.id || null;
+    const profile = getLocalWorkspaceProfile();
+
+    const workspace = ensureWorkspaceShape({
+      id: workspaceId,
+      name: draft.name,
+      description: draft.description,
+      type: draft.type,
+      joinRules: draft.joinRules,
+      created: now,
+      creatorPeerId,
+      members: [
+        {
+          id: profile.id,
+          name: profile.name,
+          peerId: creatorPeerId,
+          role: 'owner',
+          joined: now
+        }
+      ],
+      channels: [
+        { id: 'general', name: 'General', created: now }
+      ],
+      inviteCode,
+      requests: []
+    });
+
+    const strength = evaluatePasswordStrength(password);
+    workspace.security = {
+      passwordEnabled: Boolean(password),
+      passwordStrength: password ? describeStrength(strength) : 'weak',
+      passwordDigest: password ? await hashWorkspaceSecret(password) : null,
+      twoFactor: Boolean(twoFactor),
+      createdAt: now,
+      explanation: 'Protects workspace invites, history, and admin settings.'
+    };
+
+    workspace.audit = {
+      createdBy: profile.id,
+      createdAt: now
+    };
+
+    saveWorkspace(workspace);
+
+    this.flowState.resultWorkspace = workspace;
+    this.flowState.mode = 'create';
+    this.flowState.step = 'success';
+    this.flowState.draft = null;
+    this.updateAfterWorkspaceChange();
+    this.updateFlowUI();
+    this.scrollFlowIntoView();
+  }
+
+  renderJoinDetailsForm() {
+    this.flowBody.innerHTML = `
+      <div class="form-grid">
+        <form id="joinWorkspaceLookup" class="form-grid" novalidate>
+          <div class="field-group" data-field="inviteCode">
+            <label for="joinWorkspaceCode">Invite code or workspace URL</label>
+            <input type="text" id="joinWorkspaceCode" name="inviteCode" placeholder="e.g. WS-1234 or ABCDEF" value="${this.currentJoinSearch}" autocomplete="off">
+            <p class="field-hint">Paste the code or link from your host. We'll locate the workspace and handle the rest.</p>
+            <p class="field-error" hidden></p>
+          </div>
+          <div class="workspace-flow__actions">
+            <button type="submit" class="btn-primary" data-loading-text="Searching…">
+              <span class="btn-icon">🔓</span>
+              <span class="btn-label">Continue</span>
+            </button>
+            <button type="button" class="btn-secondary" data-action="back-to-mode">Back</button>
+          </div>
+          <p class="field-error" id="joinLookupError" role="alert" hidden></p>
+        </form>
+        <div>
+          <h3 style="margin-bottom: 0.75rem; color: #0f172a;">Workspaces you can access</h3>
+          <div class="workspace-flow__list" id="joinWorkspaceList"></div>
+        </div>
+      </div>
+    `;
+
+    const form = this.flowBody.querySelector('#joinWorkspaceLookup');
+    const input = form.querySelector('#joinWorkspaceCode');
+    const list = this.flowBody.querySelector('#joinWorkspaceList');
+
+    form.addEventListener('submit', event => {
+      event.preventDefault();
+      this.handleJoinLookup(form);
+    });
+
+    form.querySelector('[data-action="back-to-mode"]')?.addEventListener('click', () => this.resetFlow());
+
+    input?.addEventListener('input', () => {
+      this.currentJoinSearch = input.value;
+      this.renderJoinWorkspaceList(this.currentJoinSearch, list);
+    });
+
+    this.renderJoinWorkspaceList(this.currentJoinSearch, list);
+  }
+
+  renderJoinWorkspaceList(term = '', container = null) {
+    const list = container || this.flowBody?.querySelector('#joinWorkspaceList');
+    if (!list) {
+      return;
+    }
+
+    const normalized = term.trim().toLowerCase();
+    const inviteSearch = normalized.replace(/[^a-z0-9]/gi, '').toUpperCase();
+    const all = listWorkspaces();
+    const filtered = all.filter(workspace => {
+      if (!normalized) {
+        return workspace.type === 'public';
+      }
+      const matchName = workspace.name.toLowerCase().includes(normalized);
+      const matchId = workspace.id.toLowerCase().includes(normalized);
+      const matchInvite = workspace.inviteCode?.toLowerCase().includes(normalized);
+      const matchExactInvite = inviteSearch && workspace.inviteCode === inviteSearch;
+      return matchName || matchId || matchInvite || matchExactInvite;
+    });
+
+    if (!filtered.length) {
+      list.innerHTML = `
+        <div class="join-empty">
+          <strong>No matching workspaces.</strong> Check your invite code or consider creating a new workspace instead.
+        </div>
+      `;
+      return;
+    }
+
+    list.innerHTML = filtered.map(workspace => `
+      <article class="join-card">
+        <div class="join-card__header">
+          <div class="workspace-card-title">
+            <div class="workspace-card-icon">${workspace.name.charAt(0).toUpperCase()}</div>
+            <div>
+              <h4>${workspace.name}</h4>
+              <p>${workspace.description || 'No description provided.'}</p>
+            </div>
+          </div>
+          <button type="button" class="btn-secondary small" data-action="select-workspace" data-workspace-id="${workspace.id}">
+            <span class="btn-icon">➡️</span>
+            <span class="btn-label">Review</span>
+          </button>
+        </div>
+        <div class="join-card__meta">
+          <span class="join-card__badge">${workspace.type === 'public' ? 'Public' : 'Private'}</span>
+          <span class="join-card__badge">${formatJoinRule(workspace.joinRules)}</span>
+          <span class="join-card__badge">${workspace.members.length} members</span>
+          ${workspace.security?.passwordEnabled ? '<span class="join-card__badge">🔐 Password protected</span>' : '<span class="join-card__badge">🔓 No password</span>'}
+        </div>
+      </article>
+    `).join('');
+
+    list.querySelectorAll('[data-action="select-workspace"]').forEach(button => {
+      button.addEventListener('click', () => {
+        const id = button.getAttribute('data-workspace-id');
+        this.selectJoinTarget(id);
+      });
+    });
+  }
+
+  handleJoinLookup(form) {
+    this.clearFormErrors(form);
+    const input = form.querySelector('#joinWorkspaceCode');
+    const errorEl = form.querySelector('#joinLookupError');
+    const submitButton = form.querySelector('button[type="submit"]');
+    const value = input?.value.trim() || '';
+
+    if (!value) {
+      this.setFieldError(form, 'inviteCode', 'Enter the invite code or paste the workspace link.');
+      input?.focus();
+      return;
+    }
+
+    this.setButtonLoading(submitButton, true);
+
+    try {
+      const target = getWorkspaceByInvite(value);
+      if (!target) {
+        if (errorEl) {
+          errorEl.textContent = 'We couldn’t find a workspace with that code. Double-check the invite or ask the host to resend it.';
+          errorEl.hidden = false;
+        }
+        return;
+      }
+      this.selectJoinTarget(target.id);
+    } finally {
+      this.setButtonLoading(submitButton, false);
+    }
+  }
+
+  selectJoinTarget(workspaceId) {
+    const workspace = readWorkspace(workspaceId);
+    if (!workspace) {
+      return;
+    }
+    this.flowState.mode = 'join';
+    this.flowState.joinTarget = workspace;
+    this.flowState.resultWorkspace = null;
+    this.flowState.step = 'security';
+    this.updateFlowUI();
+    this.scrollFlowIntoView();
+  }
+
+  renderJoinSecurityStep() {
+    const workspace = this.flowState.joinTarget;
+    if (!workspace) {
+      this.flowState.step = 'details';
+      this.updateFlowUI();
+      return;
+    }
+
+    const passwordRequired = Boolean(workspace.security?.passwordEnabled && workspace.security?.passwordDigest);
+    const twoFactorEnabled = Boolean(workspace.security?.twoFactor);
+
+    this.flowBody.innerHTML = `
+      <div class="security-panel">
+        <div class="security-panel__explain">
+          <strong>${workspace.name}</strong> is ${passwordRequired ? 'password protected' : 'open to invited members'}.
+          ${passwordRequired ? 'Enter the password shared by the host to unlock settings and channels.' : 'You can join right away—no password needed.'}
+          ${twoFactorEnabled ? ' This workspace uses two-factor approval, so the host may confirm your join request.' : ''}
+        </div>
+        <form id="joinWorkspaceSecurity" class="form-grid" novalidate>
+          ${passwordRequired ? `
+            <div class="field-group" data-field="workspacePassword">
+              <label for="joinWorkspacePassword">Workspace password</label>
+              <input type="password" id="joinWorkspacePassword" name="workspacePassword" placeholder="Enter password" autocomplete="current-password" required>
+              <p class="field-hint">Ask the workspace owner if you don’t have the password yet.</p>
+              <p class="field-error" hidden></p>
+            </div>
+          ` : ''}
+          <p class="field-error" id="joinSecurityError" role="alert" hidden></p>
+          <div class="workspace-flow__actions">
+            <button type="submit" class="btn-primary" data-loading-text="Joining…">
+              <span class="btn-icon">🚀</span>
+              <span class="btn-label">${passwordRequired ? 'Unlock workspace' : 'Join workspace'}</span>
+            </button>
+            <button type="button" class="btn-secondary" data-action="back-to-join">Back</button>
+          </div>
+        </form>
+      </div>
+    `;
+
+    const form = this.flowBody.querySelector('#joinWorkspaceSecurity');
+    form.addEventListener('submit', event => {
+      event.preventDefault();
+      this.handleJoinSecuritySubmit(form, workspace);
+    });
+
+    form.querySelector('[data-action="back-to-join"]')?.addEventListener('click', () => {
+      this.flowState.step = 'details';
+      this.updateFlowUI();
+    });
+  }
+
+  async handleJoinSecuritySubmit(form, workspace) {
+    this.clearFormErrors(form);
+    const passwordRequired = Boolean(workspace.security?.passwordEnabled && workspace.security?.passwordDigest);
+    const passwordInput = form.querySelector('#joinWorkspacePassword');
+    const errorEl = form.querySelector('#joinSecurityError');
+    const submitButton = form.querySelector('button[type="submit"]');
+
+    if (passwordRequired && !passwordInput?.value.trim()) {
+      this.setFieldError(form, 'workspacePassword', 'Password is required to join this workspace.');
+      passwordInput?.focus();
+      return;
+    }
+
+    this.setButtonLoading(submitButton, true);
+
+    try {
+      if (passwordRequired && passwordInput) {
+        const digest = await hashWorkspaceSecret(passwordInput.value.trim());
+        if (digest !== workspace.security?.passwordDigest) {
+          this.setFieldError(form, 'workspacePassword', 'That password is incorrect.');
+          passwordInput.value = '';
+          passwordInput.focus();
+          return;
+        }
+      }
+
+      this.finalizeJoin(workspace);
+    } catch (error) {
+      console.warn('Unable to join workspace', error);
+      if (errorEl) {
+        errorEl.textContent = 'We hit a snag while joining. Please try again.';
+        errorEl.hidden = false;
+      }
+    } finally {
+      this.setButtonLoading(submitButton, false);
+    }
+  }
+
+  finalizeJoin(workspace) {
+    const profile = getLocalWorkspaceProfile();
+    const stored = readWorkspace(workspace.id) || workspace;
+    const safeWorkspace = ensureWorkspaceShape({ ...stored });
+
+    if (!safeWorkspace.members.some(member => member.id === profile.id)) {
+      safeWorkspace.members.push({
+        id: profile.id,
+        name: profile.name,
+        peerId: window.App?.peer?.id || null,
+        role: safeWorkspace.members.length ? 'member' : 'owner',
+        joined: Date.now()
+      });
+    }
+
+    saveWorkspace(safeWorkspace);
+
+    this.flowState.resultWorkspace = safeWorkspace;
+    this.flowState.joinTarget = safeWorkspace;
+    this.flowState.step = 'success';
+    this.flowState.mode = 'join';
+    this.updateAfterWorkspaceChange();
+    this.updateFlowUI();
+    this.scrollFlowIntoView();
+  }
+
+  renderSuccessStep() {
+    const workspace = this.flowState.resultWorkspace;
+    if (!workspace) {
+      this.resetFlow();
+      return;
+    }
+
+    const inviteLink = `${window.location.origin}/#/${workspace.id}`;
+    const mode = this.flowState.mode || 'create';
+    const badgeText = mode === 'create' ? 'Workspace ready' : 'Access granted';
+    const heading = mode === 'create' ? 'You just unlocked a secure workspace.' : 'You’re in. Say hello to your teammates!';
+
+    this.flowBody.innerHTML = `
+      <div class="success-panel">
+        <span class="success-panel__badge">${badgeText}</span>
+        <h3>${heading}</h3>
+        <div class="success-panel__meta">
+          <div class="success-meta__row">
+            <span>🔑</span>
+            <span>Invite code</span>
+            <code>${workspace.inviteCode}</code>
+          </div>
+          <div class="success-meta__row">
+            <span>🔗</span>
+            <span>Share link</span>
+            <code>${inviteLink}</code>
+          </div>
+          ${workspace.security?.passwordEnabled ? `
+            <div class="success-meta__row">
+              <span>🛡️</span>
+              <span>Password strength</span>
+              <strong>${workspace.security.passwordStrength || 'protected'}</strong>
+            </div>
+          ` : ''}
+          ${workspace.security?.twoFactor ? `
+            <div class="success-meta__row">
+              <span>✅</span>
+              <span>Two-factor approvals required</span>
+            </div>
+          ` : ''}
+        </div>
+        <div class="success-panel__actions">
+          <button type="button" class="btn-primary" data-action="enter-workspace" data-workspace-id="${workspace.id}">
+            <span class="btn-icon">➡️</span>
+            <span class="btn-label">Open workspace</span>
+          </button>
+          <button type="button" class="btn-secondary" data-action="copy-invite" data-link="${inviteLink}">
+            <span class="btn-icon">📋</span>
+            <span class="btn-label">Copy invite link</span>
+          </button>
+          <button type="button" class="btn-secondary" data-action="reset-flow">
+            <span class="btn-icon">➕</span>
+            <span class="btn-label">Start another</span>
+          </button>
+        </div>
+      </div>
+    `;
+
+    this.attachSuccessActions();
+  }
+
+  attachSuccessActions() {
+    this.flowBody.querySelector('[data-action="enter-workspace"]')?.addEventListener('click', event => {
+      const id = event.currentTarget.getAttribute('data-workspace-id');
+      enterWorkspace(id);
+    });
+
+    this.flowBody.querySelector('[data-action="copy-invite"]')?.addEventListener('click', async event => {
+      const link = event.currentTarget.getAttribute('data-link');
+      try {
+        await navigator.clipboard?.writeText(link);
+        event.currentTarget.classList.add('copied');
+        setTimeout(() => event.currentTarget.classList.remove('copied'), 1200);
+      } catch (error) {
+        window.alert(`Invite link: ${link}`);
+      }
+    });
+
+    this.flowBody.querySelector('[data-action="reset-flow"]')?.addEventListener('click', () => this.resetFlow());
+  }
+
+  renderWorkspaceList(workspaces = []) {
+    if (!this.librarySection) {
+      return;
+    }
 
     if (!workspaces.length) {
-      this.content.innerHTML = `
+      this.librarySection.innerHTML = `
         <div class="workspace-empty">
-          <div class="empty-illustration">✨</div>
-          <h2>How would you like to get started?</h2>
-          <p>Would you like to create a new workspace or join an existing one?</p>
+          <div class="empty-illustration">🌟</div>
+          <h2>No workspaces yet</h2>
+          <p>Create a new secure workspace or join one with an invite code.</p>
           <div class="workspace-empty__actions">
-            <button class="btn-primary large" data-action="create-initial-workspace">Create a new workspace</button>
-            <button class="btn-secondary large" data-action="join-initial-workspace">Join an existing workspace</button>
+            <button class="btn-primary large" data-action="start-create">Create workspace</button>
+            <button class="btn-secondary large" data-action="start-join">I have an invite</button>
           </div>
         </div>
       `;
 
-      const createButton = this.content.querySelector('[data-action="create-initial-workspace"]');
-      const joinButton = this.content.querySelector('[data-action="join-initial-workspace"]');
-
-      createButton?.addEventListener('click', showCreateWorkspaceModal);
-      joinButton?.addEventListener('click', showFindWorkspaceModal);
+      this.librarySection.querySelector('[data-action="start-create"]')?.addEventListener('click', () => this.startFlow('create'));
+      this.librarySection.querySelector('[data-action="start-join"]')?.addEventListener('click', () => this.startFlow('join'));
       return;
     }
 
-    const cards = workspaces.map(workspace => `
-      <article class="workspace-card" data-id="${workspace.id}">
-        <header class="workspace-card-header">
-          <div class="workspace-card-title">
-            <div class="workspace-card-icon">${workspace.name.charAt(0).toUpperCase()}</div>
-            <div>
-              <h3>${workspace.name}</h3>
-              <p>${workspace.description || 'No description provided.'}</p>
+    const cards = workspaces.map(workspace => {
+      const inviteLink = `${window.location.origin}/#/${workspace.id}`;
+      const securityLabel = workspace.security?.passwordEnabled ? 'Protected' : 'Open';
+      const securityIcon = workspace.security?.passwordEnabled ? '🔐' : '🔓';
+      const twoFactor = workspace.security?.twoFactor ? '<span class="workspace-pill">2FA Enabled</span>' : '';
+      return `
+        <article class="workspace-card" data-id="${workspace.id}">
+          <header class="workspace-card-header">
+            <div class="workspace-card-title">
+              <div class="workspace-card-icon">${workspace.name.charAt(0).toUpperCase()}</div>
+              <div>
+                <h3>${workspace.name}</h3>
+                <p>${workspace.description || 'No description provided.'}</p>
+              </div>
+            </div>
+            <button class="btn-secondary small" data-action="open" data-id="${workspace.id}">
+              <span class="btn-icon">➡️</span>
+              <span class="btn-label">Open</span>
+            </button>
+          </header>
+          <div class="workspace-card-body">
+            <div class="workspace-card-stat">
+              <span class="stat-number">${workspace.members.length}</span>
+              <span class="stat-label">Members</span>
+            </div>
+            <div class="workspace-card-stat">
+              <span class="stat-number">${workspace.channels.length}</span>
+              <span class="stat-label">Channels</span>
+            </div>
+            <div class="workspace-card-stat">
+              <span class="stat-number">${securityIcon} ${securityLabel}</span>
+              <span class="stat-label">Security</span>
             </div>
           </div>
-          <button class="btn-secondary small" data-action="open" data-id="${workspace.id}">Open</button>
-        </header>
-        <div class="workspace-card-body">
-          <div class="workspace-card-stat">
-            <span class="stat-number">${workspace.members.length}</span>
-            <span class="stat-label">Members</span>
-          </div>
-          <div class="workspace-card-stat">
-            <span class="stat-number">${workspace.channels.length}</span>
-            <span class="stat-label">Channels</span>
-          </div>
-          <div class="workspace-card-stat">
-            <span class="stat-number">${workspace.type === 'public' ? 'Public' : 'Private'}</span>
-            <span class="stat-label">Type</span>
-          </div>
-        </div>
-        <footer class="workspace-card-footer">
-          <span class="workspace-url">${window.location.origin}/#/${workspace.id}</span>
-          <span class="workspace-pill">${formatJoinRule(workspace.joinRules)}</span>
-        </footer>
-      </article>
-    `).join('');
+          <footer class="workspace-card-footer">
+            <span class="workspace-url" title="Invite link">${inviteLink}</span>
+            <span class="workspace-pill">${formatJoinRule(workspace.joinRules)}</span>
+            ${twoFactor}
+          </footer>
+        </article>
+      `;
+    }).join('');
 
-    this.content.innerHTML = `<div class="workspace-grid">${cards}</div>`;
+    this.librarySection.innerHTML = `
+      <div class="workspace-grid__header">
+        <h3>Your workspaces</h3>
+        <button type="button" class="btn-secondary small" data-action="start-create">
+          <span class="btn-icon">➕</span>
+          <span class="btn-label">New workspace</span>
+        </button>
+      </div>
+      <div class="workspace-grid">${cards}</div>
+    `;
 
-    this.content.querySelectorAll('[data-action="open"]').forEach(button => {
+    this.librarySection.querySelector('[data-action="start-create"]')?.addEventListener('click', () => this.startFlow('create'));
+    this.librarySection.querySelectorAll('[data-action="open"]').forEach(button => {
       button.addEventListener('click', event => {
         event.stopPropagation();
         const id = button.getAttribute('data-id');
@@ -769,12 +1348,113 @@ class WorkspaceApp {
       });
     });
 
-    this.content.querySelectorAll('.workspace-card').forEach(card => {
+    this.librarySection.querySelectorAll('.workspace-card').forEach(card => {
       card.addEventListener('click', () => {
         const id = card.getAttribute('data-id');
         enterWorkspace(id);
       });
     });
+  }
+
+  updateHeroStats() {
+    renderHeroStats(this.heroStats, this.workspaces);
+  }
+
+  updateAfterWorkspaceChange() {
+    this.workspaces = listWorkspaces();
+    this.renderWorkspaceList(this.workspaces);
+    this.updateHeroStats();
+  }
+
+  resetFlow() {
+    this.flowState = {
+      step: 'mode',
+      mode: null,
+      draft: null,
+      joinTarget: null,
+      resultWorkspace: null
+    };
+    this.currentJoinSearch = '';
+    this.updateFlowUI();
+    this.scrollFlowIntoView();
+  }
+
+  selectMode(mode, options = {}) {
+    const { reset = false, scroll = false } = options;
+
+    if (!mode) {
+      this.resetFlow();
+      return;
+    }
+
+    if (reset) {
+      this.flowState.draft = null;
+      this.flowState.joinTarget = null;
+      this.flowState.resultWorkspace = null;
+      if (mode === 'join') {
+        this.currentJoinSearch = '';
+      }
+    }
+
+    this.flowState.mode = mode;
+    if (this.flowState.step === 'mode' || reset) {
+      this.flowState.step = 'details';
+    }
+
+    this.updateFlowUI();
+    if (scroll) {
+      this.scrollFlowIntoView();
+    }
+  }
+
+  setButtonLoading(button, loading) {
+    if (!button) {
+      return;
+    }
+    if (loading) {
+      button.setAttribute('data-loading', 'true');
+      const label = button.querySelector('.btn-label');
+      if (label && !button.dataset.originalLabel) {
+        button.dataset.originalLabel = label.textContent.trim();
+        const loadingText = button.getAttribute('data-loading-text') || 'Working…';
+        label.textContent = loadingText;
+      }
+    } else {
+      button.removeAttribute('data-loading');
+      const label = button.querySelector('.btn-label');
+      if (label && button.dataset.originalLabel) {
+        label.textContent = button.dataset.originalLabel;
+        delete button.dataset.originalLabel;
+      }
+    }
+  }
+
+  clearFormErrors(form) {
+    if (!form) {
+      return;
+    }
+    form.querySelectorAll('.field-error').forEach(error => {
+      error.textContent = '';
+      error.hidden = true;
+    });
+    form.querySelectorAll('.field-group').forEach(group => {
+      group.classList.remove('has-error');
+    });
+  }
+
+  setFieldError(form, fieldName, message) {
+    if (!form) {
+      return;
+    }
+    const group = form.querySelector(`[data-field="${fieldName}"]`);
+    const error = group?.querySelector('.field-error');
+    if (group) {
+      group.classList.add('has-error');
+    }
+    if (error) {
+      error.textContent = message;
+      error.hidden = false;
+    }
   }
 }
 
@@ -783,8 +1463,6 @@ function initializeWorkspace() {
     document.addEventListener('DOMContentLoaded', initializeWorkspace, { once: true });
     return;
   }
-
-  window.closeModal = closeModal;
 
   if (!window.workspaceApp) {
     window.workspaceApp = new WorkspaceApp();
@@ -797,16 +1475,22 @@ function initializeWorkspace() {
   const findBtn = document.getElementById('findWorkspaceBtn');
 
   if (createBtn && !createBtn._initialized) {
-    createBtn.addEventListener('click', showCreateWorkspaceModal);
+    createBtn.addEventListener('click', event => {
+      event.preventDefault();
+      window.workspaceApp?.startFlow('create');
+    });
     createBtn._initialized = true;
   }
 
   if (findBtn && !findBtn._initialized) {
-    findBtn.addEventListener('click', showFindWorkspaceModal);
+    findBtn.addEventListener('click', event => {
+      event.preventDefault();
+      window.workspaceApp?.startFlow('join');
+    });
     findBtn._initialized = true;
   }
 
-  updateWorkspaceStats();
+  window.workspaceApp?.updateHeroStats();
 
   const activeRaw = localStorage.getItem(ACTIVE_WORKSPACE_KEY);
   if (activeRaw) {
@@ -824,25 +1508,11 @@ function initializeWorkspace() {
 initializeWorkspace();
 
 function updateWorkspaceStats() {
+  if (window.workspaceApp) {
+    window.workspaceApp.updateHeroStats();
+    return;
+  }
   const statsEl = document.getElementById('workspaceHeroStats');
-  if (statsEl) {
-    const workspaceCount = Object.keys(localStorage)
-      .filter(key => key.startsWith(WORKSPACE_STORAGE_PREFIX)).length;
-    statsEl.innerHTML = `
-            <div class="stat">
-                <div class="stat-number">${workspaceCount}</div>
-                <div class="stat-label">Active Workspaces</div>
-            </div>
-        `;
-  }
+  const workspaces = listWorkspaces();
+  renderHeroStats(statsEl, workspaces);
 }
-
-window.addEventListener('keydown', event => {
-  if (event.key === 'Escape') {
-    const openModalEl = document.querySelector('.modal[data-open="true"]');
-    if (openModalEl?.id) {
-      closeModal(openModalEl.id);
-    }
-  }
-});
-


### PR DESCRIPTION
## Summary
- replace the modal-based workspace entry flow with an inline guided experience that covers action selection, details, security, and success states
- refresh the workspace list and hero stats to surface security details and live counts
- swap the native storage passphrase prompt for a branded modal with strength feedback and optional session caching

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d5c617b4c08332a81d7585f15221a7