### PR TITLE
Fix workspace button by avoiding DOM id conflict

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,7 +51,7 @@ const DOM = {
   identityError: document.getElementById('identityError'),
   identitySubmitBtn: document.getElementById('identitySubmitBtn'),
   reentryContainer: document.getElementById('reentryContainer'),
-  workspaceRoot: document.getElementById('workspaceApp'),
+  workspaceRoot: document.getElementById('workspaceRoot'),
   legacyRoot: document.getElementById('legacyApp')
 };
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 
 </head>
 <body>
-  <div id="workspaceApp" class="workspace-app" role="main">
+  <div id="workspaceRoot" class="workspace-app" role="main">
     <header class="workspace-hero">
       <div class="hero-content">
         <div class="hero-badge">Persistent Workspaces</div>

--- a/workspace.js
+++ b/workspace.js
@@ -239,7 +239,7 @@ function enterWorkspace(workspaceId) {
     return;
   }
 
-  const root = document.getElementById('workspaceApp');
+  const root = document.getElementById('workspaceRoot');
   if (root) {
     root.hidden = true;
   }
@@ -267,7 +267,7 @@ function leaveWorkspaceView() {
   if (view) {
     view.remove();
   }
-  const root = document.getElementById('workspaceApp');
+  const root = document.getElementById('workspaceRoot');
   if (root) {
     root.hidden = false;
   }
@@ -400,7 +400,7 @@ function formatJoinRule(rule) {
 
 class WorkspaceApp {
   constructor() {
-    this.root = document.getElementById('workspaceApp');
+    this.root = document.getElementById('workspaceRoot');
     this.content = document.getElementById('workspaceContent');
     this.heroStats = document.getElementById('workspaceHeroStats');
     this.flowContainer = null;


### PR DESCRIPTION
## Summary
- rename the workspace landing container id so the global `window.workspaceApp` reference no longer points at a DOM node
- update workspace controller code to use the new container id, allowing the create workspace button to invoke the app controller

## Testing
- node tests/replay.js

------
https://chatgpt.com/codex/tasks/task_b_68d5cb75ca948332a8317e290f943bf6