### PR TITLE
Hide workspace hero after creating or joining

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3063,6 +3063,14 @@
   padding: 2rem 1.5rem 4rem;
 }
 
+.workspace-app--condensed {
+  padding-top: 1.5rem;
+}
+
+.workspace-app--condensed .workspace-hero {
+  display: none;
+}
+
 .workspace-hero {
   background: linear-gradient(135deg, #1d4ed8, #3b82f6);
   color: white;

--- a/workspace.js
+++ b/workspace.js
@@ -468,6 +468,7 @@ class WorkspaceApp {
     this.renderFlowShell();
     this.renderWorkspaceList(this.workspaces);
     this.updateHeroStats();
+    this.updateHeroVisibility();
   }
 
   renderFlowShell() {
@@ -566,6 +567,23 @@ class WorkspaceApp {
     }
 
     this.renderFlowBody();
+    this.updateHeroVisibility();
+  }
+
+  updateHeroVisibility() {
+    if (!this.root) {
+      return;
+    }
+
+    const hasWorkspaces = Array.isArray(this.workspaces) && this.workspaces.length > 0;
+    const flowActive = this.flowState?.step && this.flowState.step !== 'mode';
+    const shouldCondense = Boolean(this.activeWorkspaceId) || flowActive || hasWorkspaces;
+
+    if (shouldCondense) {
+      this.root.classList.add('workspace-app--condensed');
+    } else {
+      this.root.classList.remove('workspace-app--condensed');
+    }
   }
 
   renderFlowBody() {
@@ -1364,6 +1382,7 @@ class WorkspaceApp {
     this.workspaces = listWorkspaces();
     this.renderWorkspaceList(this.workspaces);
     this.updateHeroStats();
+    this.updateHeroVisibility();
   }
 
   resetFlow() {


### PR DESCRIPTION
## Summary
- hide the workspace hero banner once setup flows or saved workspaces are present
- centralize layout toggling via updateHeroVisibility so returning users land in a compact view
- add condensed layout styles for the workspace app wrapper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d5ceda9f508332929e17052013070e