### PR TITLE
Hide hero banner when workspace list is condensed

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3063,6 +3063,14 @@
   padding: 2rem 1.5rem 4rem;
 }
 
+.workspace-app--condensed {
+  padding-top: 1.5rem;
+}
+
+.workspace-app--condensed .workspace-hero {
+  display: none;
+}
+
 .workspace-hero {
   background: linear-gradient(135deg, #1d4ed8, #3b82f6);
   color: white;

--- a/workspace.js
+++ b/workspace.js
@@ -403,6 +403,7 @@ class WorkspaceApp {
     this.root = document.getElementById('workspaceRoot');
     this.content = document.getElementById('workspaceContent');
     this.heroStats = document.getElementById('workspaceHeroStats');
+    this.heroSection = this.root?.querySelector('.workspace-hero') || null;
     this.flowContainer = null;
     this.flowBody = null;
     this.librarySection = null;
@@ -468,6 +469,7 @@ class WorkspaceApp {
     this.renderFlowShell();
     this.renderWorkspaceList(this.workspaces);
     this.updateHeroStats();
+    this.updateHeroVisibility();
   }
 
   renderFlowShell() {
@@ -566,6 +568,30 @@ class WorkspaceApp {
     }
 
     this.renderFlowBody();
+    this.updateHeroVisibility();
+  }
+
+  updateHeroVisibility() {
+    if (!this.root) {
+      return;
+    }
+
+    const hasWorkspaces = Array.isArray(this.workspaces) && this.workspaces.length > 0;
+    const flowActive = this.flowState?.step && this.flowState.step !== 'mode';
+    const shouldCondense = Boolean(this.activeWorkspaceId) || flowActive || hasWorkspaces;
+
+    if (this.heroSection) {
+      this.heroSection.hidden = shouldCondense;
+    }
+
+    if (shouldCondense) {
+      this.root.classList.add('workspace-app--condensed');
+    } else {
+      this.root.classList.remove('workspace-app--condensed');
+      if (this.heroSection) {
+        this.heroSection.hidden = false;
+      }
+    }
   }
 
   renderFlowBody() {
@@ -1364,6 +1390,7 @@ class WorkspaceApp {
     this.workspaces = listWorkspaces();
     this.renderWorkspaceList(this.workspaces);
     this.updateHeroStats();
+    this.updateHeroVisibility();
   }
 
   resetFlow() {


### PR DESCRIPTION
## Summary
- track the landing hero section element when initializing the workspace app
- explicitly toggle the hero's hidden state alongside the condensed layout class so it disappears once workspaces exist

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d5ceda9f508332929e17052013070e