### PR TITLE
Defer identity prompt until a workspace is active

### DIFF
--- a/workspace.js
+++ b/workspace.js
@@ -267,6 +267,9 @@ function enterWorkspace(workspaceId) {
 
   window.workspaceApp?.setActiveWorkspace(workspace.id);
   initializeWorkspaceConnections(workspace);
+  if (window.App?.setWorkspaceContext) {
+    window.App.setWorkspaceContext(workspace.id);
+  }
 }
 
 function leaveWorkspaceView() {
@@ -281,6 +284,9 @@ function leaveWorkspaceView() {
   localStorage.removeItem(ACTIVE_WORKSPACE_KEY);
   window.workspaceApp?.setActiveWorkspace(null);
   window.workspaceApp?.renderLanding();
+  if (window.App?.setWorkspaceContext) {
+    window.App.setWorkspaceContext(null, { ensureIdentity: false });
+  }
 }
 
 function createWorkspaceUI(workspace) {


### PR DESCRIPTION
## Summary
- track the active workspace and derive identity scope from it before prompting for a password
- expose a workspace context hook so entering/leaving a workspace toggles identity prompts and storage scope
- update workspace entry to notify the chat app when a workspace is opened or exited

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d6049fd4cc833297a840d1219c80de