### PR TITLE
Fix workspace flow initialization error

### DIFF
--- a/workspace.js
+++ b/workspace.js
@@ -593,23 +593,14 @@ class WorkspaceApp {
     const flowActive = this.flowState?.step && this.flowState.step !== 'mode';
     const shouldCondense = Boolean(this.activeWorkspaceId) || flowActive || hasWorkspaces;
 
-<<<<<<< codex/hide-top-screen-section-on-room-entry-lqb70b
     if (this.heroSection) {
       this.heroSection.hidden = shouldCondense;
     }
 
-=======
->>>>>>> main
     if (shouldCondense) {
       this.root.classList.add('workspace-app--condensed');
     } else {
       this.root.classList.remove('workspace-app--condensed');
-<<<<<<< codex/hide-top-screen-section-on-room-entry-lqb70b
-      if (this.heroSection) {
-        this.heroSection.hidden = false;
-      }
-=======
->>>>>>> main
     }
   }
 


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers in the workspace hero visibility handler
- ensure the hero section visibility toggles correctly when the workspace flow is active

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_b_68d614e1ce1083329587a7c4365e6352