### PR TITLE
Display workspace invite link in the header

### DIFF
--- a/lib/workspace-view.js
+++ b/lib/workspace-view.js
@@ -71,6 +71,10 @@
           </div>
           <div class="workspace-ui__actions">
             <div class="invite-code" data-ref="inviteCode" title="Invite code">Invite code: <strong>------</strong></div>
+            <div class="workspace-share" data-ref="shareLinkContainer">
+              <span class="workspace-share__label">Invite link</span>
+              <span class="workspace-url" data-ref="shareLink" title="Invite link unavailable">Invite link unavailable</span>
+            </div>
             <button class="btn-secondary" type="button" data-action="copy-link">Copy Link</button>
             <button class="btn-primary" type="button" data-action="leave">Back to Workspaces</button>
           </div>
@@ -99,6 +103,8 @@
         inviteCode: this.container.querySelector('[data-ref="inviteCode"]'),
         channelList: this.container.querySelector('[data-ref="channels"]'),
         addChannelBtn: this.container.querySelector('[data-action="add-channel"]'),
+        shareLinkContainer: this.container.querySelector('[data-ref="shareLinkContainer"]'),
+        shareLink: this.container.querySelector('[data-ref="shareLink"]'),
         copyLinkBtn: this.container.querySelector('[data-action="copy-link"]'),
         leaveBtn: this.container.querySelector('[data-action="leave"]'),
         members: this.container.querySelector('[data-ref="members"]'),
@@ -114,7 +120,12 @@
       });
 
       this.dom.copyLinkBtn?.addEventListener('click', () => {
-        const result = this.onCopyLink(this.workspace);
+        const shareLink = this.getShareLink();
+        if (shareLink) {
+          this.options.fallbackLink = shareLink;
+        }
+        const payload = shareLink ? { ...this.workspace, shareLink } : this.workspace;
+        const result = this.onCopyLink(payload);
         if (result && typeof result.then === 'function') {
           this.dom.copyLinkBtn.disabled = true;
           Promise.resolve(result)
@@ -198,7 +209,17 @@
 
     updateWorkspace(workspace = {}) {
       this.workspace = workspace || {};
-      const { title, description, meta, inviteCode, channelList, members, membersTitle } = this.dom;
+      const {
+        title,
+        description,
+        meta,
+        inviteCode,
+        shareLinkContainer,
+        shareLink,
+        channelList,
+        members,
+        membersTitle
+      } = this.dom;
 
       if (title) {
         title.textContent = workspace.name || 'Untitled workspace';
@@ -226,6 +247,22 @@
       if (inviteCode) {
         const code = workspace.inviteCode || '------';
         inviteCode.innerHTML = `Invite code: <strong>${code}</strong>`;
+      }
+
+      if (shareLink) {
+        const link = this.getShareLink(workspace);
+        const hasLink = Boolean(link);
+        if (shareLinkContainer) {
+          shareLinkContainer.hidden = !hasLink;
+        }
+        if (hasLink) {
+          shareLink.textContent = link;
+          shareLink.setAttribute('title', `Invite link: ${link}`);
+          this.options.fallbackLink = link;
+        } else {
+          shareLink.textContent = 'Invite link unavailable';
+          shareLink.setAttribute('title', 'Invite link unavailable');
+        }
       }
 
       if (channelList) {
@@ -344,6 +381,18 @@
           <p>This is the start of the channel. Share the invite code with teammates to collaborate.</p>
         </div>
       `;
+    }
+
+    getShareLink(workspace = this.workspace) {
+      const id = workspace?.id;
+      if (!id) {
+        return '';
+      }
+      const origin = this.window?.location?.origin;
+      if (origin) {
+        return `${origin}/#/workspace/${id}`;
+      }
+      return `#/workspace/${id}`;
     }
   }
 

--- a/styles.css
+++ b/styles.css
@@ -4761,6 +4761,23 @@
   align-items: flex-end;
 }
 
+.workspace-share {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  text-align: right;
+  max-width: min(320px, 100%);
+}
+
+.workspace-share__label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.workspace-share .workspace-url {
+  word-break: break-word;
+}
+
 .workspace-ui__layout {
   display: grid;
   grid-template-columns: 220px minmax(0, 1fr) 260px;


### PR DESCRIPTION
## Summary
- show the shareable workspace invite URL alongside the copy button on the workspace view
- compute and surface the workspace invite link for clipboard fallback handling
- style the invite link block so the URL wraps cleanly in the header

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d6e8cbc1148332a41f040d7a143aa0