### PR TITLE
Fix workspace launch flow and harden join/create UI

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3703,6 +3703,22 @@
   gap: 1rem;
 }
 
+.workspace-message {
+  background: #e0f2fe;
+  color: #0c4a6e;
+  border: 1px solid #bae6fd;
+  border-radius: 12px;
+  padding: 0.875rem 1rem;
+  margin-bottom: 1rem;
+  font-weight: 500;
+}
+
+.workspace-message[data-variant="error"] {
+  background: #fee2e2;
+  border-color: #fecaca;
+  color: #7f1d1d;
+}
+
 @media (min-width: 600px) {
   .workspace-empty__actions {
     flex-direction: row;


### PR DESCRIPTION
## Summary
- wait for the workspace view component to load before opening a workspace and provide clearer fallbacks when loading fails
- guard workspace persistence helpers and channel creation so local storage errors surface cleanly and membership updates stay consistent
- surface actionable status banners in the workspace library and style them for visibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d6ea44d70c8332a30d90385bd01c94